### PR TITLE
GDCDEVOPS-534 fix admin script again

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-05-04T20:33:54Z",
+  "generated_at": "2020-07-25T00:53:47Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -49,7 +49,7 @@
         "hashed_secret": "f0e2d8610edefa0c02b673dcac7964b02ce3e890",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 12,
+        "line_number": 14,
         "type": "Basic Auth Credentials"
       }
     ],

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,7 @@ COPY wsgi.py /var/www/indexd/
 COPY bin/indexd /var/www/indexd/ 
 COPY --from=build /usr/local/lib/python3.5/dist-packages /usr/local/lib/python3.5/dist-packages
 
+# Make indexd CLI utilities available for, e.g., DB schema migration.
+COPY --from=build /usr/local/bin/*index* /usr/local/bin/
+
 WORKDIR /var/www/indexd

--- a/bin/index_admin.py
+++ b/bin/index_admin.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import argparse
 import sys
 from cdislogging import get_logger

--- a/bin/migrate_index.py
+++ b/bin/migrate_index.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 """
 The index sqlalchemy driver __init__ function runs all the necessary migration
 functions. This will run every migration from the current version as noted in

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
             'schemas/*',
         ]
     },
+    scripts=["bin/index_admin.py", "bin/indexd", "bin/migrate_index.py"],
     install_requires=[
         'flask~=1.1',
         'jsonschema~=2.5',

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,20 @@
 [tox]
 envlist = py27, py35, py36
 skip_missing_interpreters = true
-requires = pip >= 20.1.1
+requires =
+    pip >= 20.1.1
+    virtualenv >= 20.0.21
 
 [testenv]
-whitelist_externals= /bin/bash
-                     /usr/bin/wget
-                     /usr/local/bin/wget
-                     /usr/bin/java
-deps= -rrequirements.txt
-      -rdev-requirements.txt
-commands=
+whitelist_externals =
+    /bin/bash
+    /usr/bin/wget
+    /usr/local/bin/wget
+    /usr/bin/java
+deps =
+    -rrequirements.txt
+    -rdev-requirements.txt
+commands =
     wget -N https://oss.sonatype.org/content/repositories/releases/io/swagger/swagger-codegen-cli/2.3.1/swagger-codegen-cli-2.3.1.jar
     java -jar swagger-codegen-cli-2.3.1.jar generate -i openapis/swagger.yaml -l python -o swagger_client
     bash -ec "cd swagger_client/; python setup.py install; cd .."


### PR DESCRIPTION
Include the scripts from the indexd `bin` directory in the setuptools build and the Docker image. I accidentally removed them in https://github.com/NCI-GDC/indexd/pull/36. :(

I made this more complicated than it might need to be by having setuptools install the scripts, and then copying the installed scripts into a directory that's in the PATH. This makes the scripts easier to execute, but would require updates to other scripts that invoke them to use the new style, so I could be convinced to make the scripts work at the old location.

Set a minimum virtualenv version in `tox.ini` to work around random Travis build failures that were apparently caused by an old virtualenv version pulling in an old pip version.