### PR TITLE
fix macOS spawn default

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-03-09T16:23:06Z",
+  "generated_at": "2021-07-21T17:19:57Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -76,14 +76,14 @@
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 21,
+        "line_number": 22,
         "type": "Basic Auth Credentials"
       },
       {
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 83,
+        "line_number": 84,
         "type": "Secret Keyword"
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-07-21T17:26:50Z",
+  "generated_at": "2021-07-29T16:12:20Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -76,14 +76,14 @@
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 23,
+        "line_number": 21,
         "type": "Basic Auth Credentials"
       },
       {
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 85,
+        "line_number": 83,
         "type": "Secret Keyword"
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-07-21T17:19:57Z",
+  "generated_at": "2021-07-21T17:26:50Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -76,14 +76,14 @@
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 23,
         "type": "Basic Auth Credentials"
       },
       {
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 84,
+        "line_number": 85,
         "type": "Secret Keyword"
       }
     ],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!groovy
 
-library identifier: "jenkins-lib@develop"
+library identifier: "jenkins-lib@master"
 dockerPipeline{
     // testBranches = '(develop|master|release.*)'
 }

--- a/indexd_test_utils/__init__.py
+++ b/indexd_test_utils/__init__.py
@@ -151,13 +151,12 @@ def indexd_server():
     hostname = 'localhost'
     port = 8001
     debug = False
+    proc_handler = mp.Process
     if six.PY3:
         # Note: explicitly specifying fork, as spawn is the default in
         # py3.8+ on macos.
         proc_handler = mp.get_context("fork").Process
-    else:
-        # fork is the default on Python 2
-        proc_handler = mp.Process
+
     indexd = proc_handler(
         target=app.run,
         args=(hostname, port),

--- a/indexd_test_utils/__init__.py
+++ b/indexd_test_utils/__init__.py
@@ -3,6 +3,7 @@ import random
 import uuid
 from multiprocessing import Process
 import multiprocessing as mp
+import six
 
 import pytest
 import requests
@@ -150,6 +151,13 @@ def indexd_server():
     hostname = 'localhost'
     port = 8001
     debug = False
+    if six.PY3:
+        # Note: explicitly specifying fork, as spawn is the default in
+        # py3.8+ on macos.
+        proc_handler = mp.get_context("fork").Process
+    else:
+        # fork is the default on Python 2
+        proc_handler = mp.Process
     proc_handler = mp.get_context("fork").Process
     indexd = proc_handler(
         target=app.run,

--- a/indexd_test_utils/__init__.py
+++ b/indexd_test_utils/__init__.py
@@ -151,23 +151,13 @@ def indexd_server():
     hostname = 'localhost'
     port = 8001
     debug = False
-    proc_handler = mp.Process
-    if six.PY3 and sys.platform == 'darwin':
-        # Note: explicitly specifying fork, as spawn is the default in
-        # py3.8+ on macos.
-        proc_handler = mp.get_context("fork").Process
-
-    indexd = proc_handler(
-        target=app.run,
-        args=(hostname, port),
-        kwargs={'debug': debug},
-    )
-    indexd.start()
+    import threading
+    t = threading.Thread(target=app.run, kwargs={'host': hostname, 'port': port, 'debug': debug})
+    t.setDaemon(True)
+    t.start()
     wait_for_indexd_alive(port)
 
     yield MockServer(port=port)
-    indexd.terminate()
-    wait_for_indexd_not_alive(port)
 
 
 def wait_for_indexd_alive(port):

--- a/indexd_test_utils/__init__.py
+++ b/indexd_test_utils/__init__.py
@@ -1,9 +1,9 @@
 import hashlib
 import random
 import uuid
-from multiprocessing import Process
 import multiprocessing as mp
 import six
+import sys
 
 import pytest
 import requests
@@ -152,7 +152,7 @@ def indexd_server():
     port = 8001
     debug = False
     proc_handler = mp.Process
-    if six.PY3:
+    if six.PY3 and sys.platform == 'darwin':
         # Note: explicitly specifying fork, as spawn is the default in
         # py3.8+ on macos.
         proc_handler = mp.get_context("fork").Process

--- a/indexd_test_utils/__init__.py
+++ b/indexd_test_utils/__init__.py
@@ -158,7 +158,6 @@ def indexd_server():
     else:
         # fork is the default on Python 2
         proc_handler = mp.Process
-    proc_handler = mp.get_context("fork").Process
     indexd = proc_handler(
         target=app.run,
         args=(hostname, port),

--- a/indexd_test_utils/__init__.py
+++ b/indexd_test_utils/__init__.py
@@ -2,6 +2,7 @@ import hashlib
 import random
 import uuid
 from multiprocessing import Process
+import multiprocessing as mp
 
 import pytest
 import requests
@@ -149,8 +150,8 @@ def indexd_server():
     hostname = 'localhost'
     port = 8001
     debug = False
-
-    indexd = Process(
+    proc_handler = mp.get_context("fork").Process
+    indexd = proc_handler(
         target=app.run,
         args=(hostname, port),
         kwargs={'debug': debug},

--- a/indexd_test_utils/__init__.py
+++ b/indexd_test_utils/__init__.py
@@ -1,12 +1,10 @@
 import hashlib
 import random
 import uuid
-import multiprocessing as mp
-import six
-import sys
-
+import threading
 import pytest
 import requests
+
 from indexclient.client import Document, IndexClient
 from indexd import get_app
 from indexd.alias.drivers.alchemy import (
@@ -151,7 +149,6 @@ def indexd_server():
     hostname = 'localhost'
     port = 8001
     debug = False
-    import threading
     t = threading.Thread(target=app.run, kwargs={'host': hostname, 'port': port, 'debug': debug})
     t.setDaemon(True)
     t.start()


### PR DESCRIPTION
https://jira.opensciencedatacloud.org/browse/DEV-809
Python 3.8 set the default multiprocessing start mode to spawn for macOS. Fork is default for ubuntu. Assert fork mode is used for macOS as well.