### PR TITLE
Feat/dev 317

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,14 @@ pip install -r dev-requirements.txt -r requirements.txt
 swagger-codegen generate -i openapis/swagger.yaml -l python -o swagger_client
 cd swagger_client; python setup.py develop; cd -
 py.test -v tests/
+
+```
+### MacOS
+If building psycopg2 fails during install, try the following:
+```bash
+brew install openssl
+export LDFLAGS="-L/usr/local/opt/openssl/lib"
+export CPPFLAGS="-I/usr/local/opt/openssl/include"
 ```
 
 ## Testing with Docker

--- a/indexd/blueprint.py
+++ b/indexd/blueprint.py
@@ -2,12 +2,11 @@ import re
 import flask
 import jsonschema
 
-from indexclient.client import IndexClient
 from doiclient.client import DOIClient
 from dosclient.client import DOSClient
 
+from indexd.client import IndexClient
 from indexd.utils import hint_match
-
 from indexd.errors import AuthError
 from indexd.errors import UserError
 from indexd.alias.errors import NoRecordFound as AliasNoRecordFound

--- a/indexd/client.py
+++ b/indexd/client.py
@@ -1,0 +1,123 @@
+try:
+    from urlparse import urljoin
+except ImportError:
+    from urllib.parse import urljoin
+
+import requests
+
+
+def handle_error(resp):
+    if 400 <= resp.status_code < 600:
+        try:
+            json = resp.json()
+            resp.reason = json["error"]
+        except KeyError:
+            pass
+        finally:
+            resp.raise_for_status()
+
+
+class IndexClient(object):
+
+    def __init__(self, baseurl, version="v0", auth=None):
+        self.auth = auth
+        self.url = baseurl
+        self.version = version
+
+    def url_for(self, *path):
+        return urljoin(self.url, "/".join(path))
+
+
+    def global_get(self, did, no_dist=False):
+        """
+        Makes a web request to the Indexd service global endpoint to retrieve
+        an index document record.
+
+        :param str did:
+            The UUID for the index record we want to retrieve.
+
+        :param boolean no_dist:
+            *optional* Specify if we want distributed search or not
+
+        :returns: A Document object representing the index record
+        """
+        try:
+            if no_dist:
+                response = self._get(did, params={'no_dist': ''})
+            else:
+                response = self._get(did)
+        except requests.HTTPError as e:
+            if e.response.status_code == 404:
+                return None
+            else:
+                raise e
+
+        return Document(self, did, json=response.json())
+
+    def get(self, did):
+        """
+        Makes a web request to the Indexd service to retrieve an index document record.
+
+        :param str did:
+            The UUID for the index record we want to retrieve.
+
+        :returns: A Document object representing the index record
+        """
+        try:
+            response = self._get("index", did)
+        except requests.HTTPError as e:
+            if e.response.status_code == 404:
+                return None
+            else:
+                raise e
+
+        return Document(self, did, json=response.json())
+
+    def _get(self, *path, **kwargs):
+        resp = requests.get(self.url_for(*path), **kwargs)
+        handle_error(resp)
+        return resp
+
+
+class Document(object):
+
+    def __init__(self, client, did, json=None):
+        self.client = client
+        self.did = did
+        self._fetched = False
+        self._deleted = False
+        self._load(json)
+
+    def __eq__(self, other_doc):
+        """
+        equals `==` operator overload
+        """
+        return self.did == other_doc.did
+
+    def __ne__(self, other_doc):
+        """
+        not equals `!=` operator overload
+        """
+        return self.did != other_doc.did
+
+    def __hash__(self):
+        return hash(self.did)
+
+    def __lt__(self, other_doc):
+        return self.did < other_doc.did
+
+    def __gt__(self, other_doc):
+        return self.did > other_doc.did
+
+    def __repr__(self):
+        """
+        String representation of a Document
+
+        Example:
+            <Document(size=1, form=object, file_name=filename.txt, ...)>
+        """
+        attributes = ', '.join([
+            '{}={}'.format(attr, self.__dict__[attr])
+            for attr in self._attrs
+        ])
+        return '<Document(' + attributes + ')>'

--- a/indexd/client.py
+++ b/indexd/client.py
@@ -1,3 +1,7 @@
+# Note: Code below is taken from the indexclient client.py 
+# https://github.com/NCI-GDC/indexclient/blob/master/indexclient/client.py.
+# Changes to this code might also require changes to indexclient
+
 try:
     from urlparse import urljoin
 except ImportError:

--- a/indexd/default_settings.py
+++ b/indexd/default_settings.py
@@ -11,7 +11,7 @@ AUTO_MIGRATE = True
 SQLALCHEMY_VERBOSE = (
     os.getenv('INDEXD_VERBOSE', '').lower() in ['1', 'yes', 'true']
 )
-PG_URL = 'postgres://test:test@localhost/indexd_test'
+PG_URL = 'postgresql://test:test@localhost/indexd_test'
 
 CONFIG['INDEX'] = {
     'driver': SQLAlchemyIndexDriver(

--- a/indexd/utils.py
+++ b/indexd/utils.py
@@ -22,7 +22,7 @@ def try_drop_test_data(
 
     # Using an engine that connects to the `postgres` database allows us to
     # create a new database.
-    engine = create_engine("postgres://{user}@{host}/{name}".format(
+    engine = create_engine("postgresql://{user}@{host}/{name}".format(
         user=root_user, host=host, name=database))
 
     if sqlalchemy_utils.database_exists(engine.url):
@@ -41,7 +41,7 @@ def setup_database(
 
     # Create an engine connecting to the `postgres` database allows us to
     # create a new database from there.
-    engine = create_engine("postgres://{user}@{host}/{name}".format(
+    engine = create_engine("postgresql://{user}@{host}/{name}".format(
         user=root_user, host=host, name=database))
     if not sqlalchemy_utils.database_exists(engine.url):
         sqlalchemy_utils.create_database(engine.url)

--- a/indexd_test_utils/__init__.py
+++ b/indexd_test_utils/__init__.py
@@ -18,7 +18,7 @@ from indexd.index.drivers.alchemy import (
 )
 from indexd.utils import setup_database, try_drop_test_data
 
-PG_URL = 'postgres://test:test@localhost/indexd_test'
+PG_URL = 'postgresql://test:test@localhost/indexd_test'
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
         "sqlalchemy-utils>=0.32,<0.36.4",
         "psycopg2~=2.7",
         "cdislogging~=1.0",
-        "indexclient @ git+https://github.com/NCI-GDC/indexclient.git@2.0.0#egg=indexclient",
         "doiclient @ git+https://github.com/uc-cdis/doiclient.git@1.0.0#egg=doiclient",
         "dosclient @ git+https://github.com/uc-cdis/dosclient.git@1.0.0#egg=dosclient",
         "future~=0.18",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ from indexd_test_utils import (
     setup_indexd_test_database,
 )
 
-PG_URL = 'postgres://test:test@localhost/indexd_test'
+PG_URL = 'postgresql://test:test@localhost/indexd_test'
 
 
 @pytest.fixture

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -20,7 +20,7 @@ from tests.util import make_sql_statement
 
 Base = declarative_base()
 
-TEST_DB = 'postgres://postgres@localhost/test_migration_db'
+TEST_DB = 'postgresql://postgres@localhost/test_migration_db'
 
 INDEX_TABLES = {
     'index_record': [


### PR DESCRIPTION
https://jira.opensciencedatacloud.org/browse/DEV-317

In SQLAlchemy 0.6, the dialect was renamed to postgresql; however, SQLAlchemy continued to support the old dialect name with a warning. This may become unsupported in the future.
