### PR TITLE
dev-317: update dialect

### DIFF
--- a/indexd/default_settings.py
+++ b/indexd/default_settings.py
@@ -11,7 +11,7 @@ AUTO_MIGRATE = True
 SQLALCHEMY_VERBOSE = (
     os.getenv('INDEXD_VERBOSE', '').lower() in ['1', 'yes', 'true']
 )
-PG_URL = 'postgres://test:test@localhost/indexd_test'
+PG_URL = 'postgresql://test:test@localhost/indexd_test'
 
 CONFIG['INDEX'] = {
     'driver': SQLAlchemyIndexDriver(

--- a/indexd/utils.py
+++ b/indexd/utils.py
@@ -22,7 +22,7 @@ def try_drop_test_data(
 
     # Using an engine that connects to the `postgres` database allows us to
     # create a new database.
-    engine = create_engine("postgres://{user}@{host}/{name}".format(
+    engine = create_engine("postgresql://{user}@{host}/{name}".format(
         user=root_user, host=host, name=database))
 
     if sqlalchemy_utils.database_exists(engine.url):
@@ -41,7 +41,7 @@ def setup_database(
 
     # Create an engine connecting to the `postgres` database allows us to
     # create a new database from there.
-    engine = create_engine("postgres://{user}@{host}/{name}".format(
+    engine = create_engine("postgresql://{user}@{host}/{name}".format(
         user=root_user, host=host, name=database))
     if not sqlalchemy_utils.database_exists(engine.url):
         sqlalchemy_utils.create_database(engine.url)

--- a/indexd_test_utils/__init__.py
+++ b/indexd_test_utils/__init__.py
@@ -18,7 +18,7 @@ from indexd.index.drivers.alchemy import (
 )
 from indexd.utils import setup_database, try_drop_test_data
 
-PG_URL = 'postgres://test:test@localhost/indexd_test'
+PG_URL = 'postgresql://test:test@localhost/indexd_test'
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ from indexd_test_utils import (
     setup_indexd_test_database,
 )
 
-PG_URL = 'postgres://test:test@localhost/indexd_test'
+PG_URL = 'postgresql://test:test@localhost/indexd_test'
 
 
 @pytest.fixture

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -20,7 +20,7 @@ from tests.util import make_sql_statement
 
 Base = declarative_base()
 
-TEST_DB = 'postgres://postgres@localhost/test_migration_db'
+TEST_DB = 'postgresql://postgres@localhost/test_migration_db'
 
 INDEX_TABLES = {
     'index_record': [


### PR DESCRIPTION
https://jira.opensciencedatacloud.org/browse/DEV-317

In SQLAlchemy 0.6, the dialect was renamed to postgresql; however, SQLAlchemy continued to support the old dialect name with a warning. This may become unsupported in the future.