### PR TITLE
DEV-1032: Add not deleted parameter to query endpoints

### DIFF
--- a/indexd/index/drivers/query/urls.py
+++ b/indexd/index/drivers/query/urls.py
@@ -23,12 +23,25 @@ class AlchemyURLsQueryDriver(URLsQueryDriver):
         """
         self.driver = alchemy_driver
 
-    def query_urls(self, exclude=None, include=None, versioned=None, offset=0, limit=1000, fields="did,urls", **kwargs):
-
+    def query_urls(self, exclude=None, include=None, versioned=None, not_deleted=True, offset=0, limit=1000,
+                   fields="did,urls", **kwargs):
+        """
+        Get a list of document fields matching the search parameters
+        Args:
+            include (str): If defined, at least one URL in a document must contain this string to be included in search.
+            exclude (str): If defined, no URL in a document may contain this string to be included in search.
+            versioned (bool): If None (default), search documents regardless of whether they are versioned or not. If
+                True, filter only for versioned documents. If False, filter only for un-versioned documents.
+            not_deleted (bool): If True (default), exclude deleted documents from search. If False, include deleted
+                and not deleted documents in search.
+            offset (int): Defines a position offset, the first n results to skip
+            limit (int): Defines the number of results to return
+            fields (str): Comma separated list (defaults to did,urls) of fields to return
+        Returns:
+            list (dict): matching documents with specified return fields
+        """
         if kwargs:
             raise UserError("Unexpected query parameter(s) {}".format(kwargs.keys()))
-
-        versioned = versioned.lower() in ["true", "t", "yes", "y"] if versioned else None
 
         with self.driver.session as session:
             # special database specific functions dependent of the selected dialect
@@ -36,47 +49,56 @@ class AlchemyURLsQueryDriver(URLsQueryDriver):
 
             query = session.query(
                 IndexRecordUrlMetadataJsonb.did,
-                q_func['string_agg'](IndexRecordUrlMetadataJsonb.url, ","),
+                q_func["string_agg"](IndexRecordUrlMetadataJsonb.url, ","),
             )
 
-            # add version filter if versioned is not None
-            if versioned is True:  # retrieve only those with a version number
-                query = query.outerjoin(IndexRecord)
-                query = query.filter(IndexRecord.version.isnot(None))
-            elif versioned is False: # retrieve only those without a version number
-                query = query.outerjoin(IndexRecord)
-                query = query.filter(~IndexRecord.version.isnot(None))
+            # handle filters for versioned and/or not_deleted flags
+            query = self._filter_indexrecord(query, versioned, not_deleted)
 
             query = query.group_by(IndexRecordUrlMetadataJsonb.did)
 
             # add url filters
             if include and exclude:
-                query = query.having(and_(~q_func['string_agg'](IndexRecordUrlMetadataJsonb.url, ",").contains(exclude),
-                                          q_func['string_agg'](IndexRecordUrlMetadataJsonb.url, ",").contains(include)))
+                query = query.having(and_(~q_func["string_agg"](IndexRecordUrlMetadataJsonb.url, ",").contains(exclude),
+                                          q_func["string_agg"](IndexRecordUrlMetadataJsonb.url, ",").contains(include)))
             elif include:
-                query = query.having(q_func['string_agg'](IndexRecordUrlMetadataJsonb.url, ",").contains(include))
+                query = query.having(q_func["string_agg"](IndexRecordUrlMetadataJsonb.url, ",").contains(include))
             elif exclude:
-                query = query.having(~q_func['string_agg'](IndexRecordUrlMetadataJsonb.url, ",").contains(exclude))
-            # [('did', 'urls')]
+                query = query.having(~q_func["string_agg"](IndexRecordUrlMetadataJsonb.url, ",").contains(exclude))
+            # [("did", "urls")]
             record_list = query.order_by(IndexRecordUrlMetadataJsonb.did.asc()).offset(offset).limit(limit).all()
         return self._format_response(fields, record_list)
 
-    def query_metadata_by_key(self, key, value, url=None, versioned=None, offset=0,
+    def query_metadata_by_key(self, key, value, url=None, versioned=None, not_deleted=True, offset=0,
                               limit=1000, fields="did,urls,rev", **kwargs):
-
+        """
+        Get a list of document fields matching the search parameters
+        Args:
+            key (str): metadata key
+            value (str): metadata value for key
+            url (str): full url or pattern for limit to
+            versioned (bool): If None (default), search documents regardless of whether they are versioned or not. If
+                True, filter only for versioned documents. If False, filter only for un-versioned documents.
+            not_deleted (bool): If True (default), exclude deleted documents from search. If False, include deleted
+                and not deleted documents in search.
+            offset (int): Defines a position offset, the first n results to skip
+            limit (int): Defines the number of results to return
+            fields (str): Comma separated list (defaults to did,urls) of fields to return
+        Returns:
+            list (dict): matching documents with specified return fields
+        """
         if kwargs:
             raise UserError("Unexpected query parameter(s) {}".format(kwargs.keys()))
 
-        versioned = versioned.lower() in ["true", "t", "yes", "y"] if versioned else None
         with self.driver.session as session:
             query = session.query(IndexRecordUrlMetadataJsonb.did,
                                   IndexRecordUrlMetadataJsonb.url,
                                   IndexRecord.rev)
-            if key == 'type':
+            if key == "type":
                 query = query.filter(
                     IndexRecord.did == IndexRecordUrlMetadataJsonb.did,
                     IndexRecordUrlMetadataJsonb.type == value)
-            elif key == 'state':
+            elif key == "state":
                 query = query.filter(
                     IndexRecord.did == IndexRecordUrlMetadataJsonb.did,
                     IndexRecordUrlMetadataJsonb.state == value)
@@ -85,11 +107,8 @@ class AlchemyURLsQueryDriver(URLsQueryDriver):
                     IndexRecord.did == IndexRecordUrlMetadataJsonb.did,
                     IndexRecordUrlMetadataJsonb.urls_metadata[key].astext == value)
 
-            # filter by version
-            if versioned is True:
-                query = query.filter(IndexRecord.version.isnot(None))
-            elif versioned is False:
-                query = query.filter(~IndexRecord.version.isnot(None))
+            # handle filters for versioned and/or not_deleted flags
+            query = self._filter_indexrecord(query, versioned, not_deleted)
 
             # add url filter
             if url:
@@ -98,6 +117,26 @@ class AlchemyURLsQueryDriver(URLsQueryDriver):
             # [('did', 'url', 'rev')]
             record_list = query.order_by(IndexRecordUrlMetadataJsonb.did.asc()).offset(offset).limit(limit).all()
         return self._format_response(fields, record_list)
+
+    @staticmethod
+    def _filter_indexrecord(query, versioned, not_deleted):
+        """ Handles outer join to IndexRecord for versioned and not_deleted filters if filter flags exist """
+        if versioned is not None or not_deleted:
+            query = query.outerjoin(IndexRecord)
+
+            # handle not deleted filter
+            if not_deleted:
+                query = query.filter(
+                    (func.lower(IndexRecord.index_metadata["deleted"].astext) == "true").isnot(True)
+                )
+
+            # handle version filter if not None
+            if versioned is True:  # retrieve only those with a version number
+                query = query.filter(IndexRecord.version.isnot(None))
+            elif versioned is False:  # retrieve only those without a version number
+                query = query.filter(~IndexRecord.version.isnot(None))
+
+        return query
 
     @staticmethod
     def _format_response(requested_fields, record_list):

--- a/indexd/urls/blueprint.py
+++ b/indexd/urls/blueprint.py
@@ -1,13 +1,12 @@
 import json
 
-from flask import Blueprint, Response, request
-from flask.json import jsonify
+import flask
 
 from indexd.errors import UserError
 from indexd.index.drivers.query.urls import AlchemyURLsQueryDriver
 
 
-blueprint = Blueprint("urls", __name__)
+blueprint = flask.Blueprint("urls", __name__)
 
 
 @blueprint.route("/q", methods=["GET"])
@@ -16,7 +15,8 @@ def query():
     Params:
         exclude (str): only include documents (did) with urls that does not match this pattern
         include (str): only include documents (did) with a url matching this pattern
-        version (str): return only records with version number
+        versioned (str): return only records with version number
+        not_deleted (str): return only records not marked as deleted
         fields (str): comma separated list of fields to return, if not specified return all fields
         limit (str): max results to return
         offset (str): where to start the next query from
@@ -29,9 +29,14 @@ def query():
                 ]
             `
     """
+    args_dict = flask.request.args.to_dict()
+    if "versioned" in args_dict.keys():
+        args_dict["versioned"] = args_dict["versioned"].lower() in ["true", "t", "yes", "y"]
+    if "not_deleted" in args_dict.keys():
+        args_dict["not_deleted"] = args_dict["not_deleted"].lower() not in ["false", "f", "no", "n"]
 
-    record_list = blueprint.driver.query_urls(**request.args.to_dict())
-    return Response(json.dumps(record_list, indent=2, separators=(', ', ': ')), 200, mimetype="application/json")
+    record_list = blueprint.driver.query_urls(**args_dict)
+    return flask.Response(json.dumps(record_list, indent=2, separators=(', ', ': ')), 200, mimetype="application/json")
 
 
 @blueprint.route("/metadata/q")
@@ -42,7 +47,8 @@ def query_metadata():
         value (str): metadata value for key
         url (str): full url or pattern for limit to
         fields (str): comma separated list of fields to return, if not specified return all fields
-        version (str): filter only records with a version number
+        versioned (str): filter only records with a version number
+        not_deleted (str): return only records not marked as deleted
         limit (str): max results to return
         offset (str): where to start the next query from
     Returns:
@@ -54,9 +60,14 @@ def query_metadata():
                 ]
             `
     """
+    args_dict = flask.request.args.to_dict()
+    if "versioned" in args_dict.keys():
+        args_dict["versioned"] = args_dict["versioned"].lower() in ["true", "t", "yes", "y"]
+    if "not_deleted" in args_dict.keys():
+        args_dict["not_deleted"] = args_dict["not_deleted"].lower() not in ["false", "f", "no", "n"]
 
-    record_list = blueprint.driver.query_metadata_by_key(**request.args.to_dict())
-    return Response(json.dumps(record_list, indent=2, separators=(', ', ': ')), 200, mimetype="application/json")
+    record_list = blueprint.driver.query_metadata_by_key(**args_dict)
+    return flask.Response(json.dumps(record_list, indent=2, separators=(', ', ': ')), 200, mimetype="application/json")
 
 
 @blueprint.record
@@ -68,4 +79,4 @@ def pre_config(state):
 
 @blueprint.errorhandler(UserError)
 def handle_user_error(err):
-    return jsonify(error=str(err)), 400
+    return flask.jsonify(error=str(err)), 400

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -854,11 +854,18 @@ paths:
           type: string
       - name: versioned
         in: query
-        description: if true search for documents with a version set, else search
-          documents without version
+        description: if true search for documents with a version set, if false search
+          documents without version, else search both versioned and unversioned 
+          documents
         schema:
           type: boolean
-          default: false
+      - name: not_deleted
+        in: query
+        description: if true search documents not flagged as deleted, else search all
+          documents regardless of deleted status
+        schema:
+          type: boolean
+          default: true
       - name: limit
         in: query
         description: maximum rows to return
@@ -907,11 +914,18 @@ paths:
           type: string
       - name: versioned
         in: query
-        description: if true search for documents with a version set, else search
-          documents without version
+        description: if true search for documents with a version set, if false search
+          documents without version, else search both versioned and unversioned 
+          documents
         schema:
           type: boolean
-          default: false
+      - name: not_deleted
+        in: query
+        description: if true search documents not flagged as deleted, else search all
+          documents regardless of deleted status
+        schema:
+          type: boolean
+          default: true
       - name: limit
         in: query
         description: maximum rows to return

--- a/tests/test_urls_endpoints.py
+++ b/tests/test_urls_endpoints.py
@@ -31,17 +31,25 @@ def test_data(swg_index_client):
             doc["urls_metadata"][url_x] = {"state": "uploaded"}
             url_x_type -= 1
         swg_index_client.add_index_entry(doc)
-    return url_x_count, versioned_count, unversioned_count
+
+    deleted_count = system_random.randint(5, 10)
+    for _ in range(deleted_count):
+        doc = get_doc(has_metadata=False)
+        doc["metadata"] = {"deleted": "True"}
+        swg_index_client.add_index_entry(doc)
+
+    return url_x_count, versioned_count, unversioned_count, deleted_count
 
 
 def test_query_urls(swg_index_client, swg_query_client, test_data):
     """
+    Tests query urls endpoint
     Args:
-        swg_index_client (swagger_client.api.indexurls_api.IndexApi):
+        swg_index_client (swagger_client.api.indexurls_api.IndexApi): index api client
         swg_query_client (swagger_client.api.indexurls_api.IndexurlsApi): urls api client
-        test_data (tuple[int, int, int]:
+        test_data (tuple[int, int, int, int]: test data counts
     """
-    url_x_count, versioned_count, unversioned_count = test_data
+    url_x_count, versioned_count, unversioned_count, deleted_count = test_data
     # test get all
     urls_list = swg_query_client.query_urls()
     print(urls_list)
@@ -55,6 +63,10 @@ def test_query_urls(swg_index_client, swg_query_client, test_data):
     urls_list = swg_query_client.query_urls(versioned=False)
     assert len(urls_list) == unversioned_count
 
+    # test deleted
+    urls_list = swg_query_client.query_urls(not_deleted=False)
+    assert len(urls_list) == versioned_count + unversioned_count + deleted_count
+
     # test exclude url
     urls_list = swg_query_client.query_urls(exclude="awesome-x")
     assert len(urls_list) == versioned_count + unversioned_count - 2 * url_x_count
@@ -66,28 +78,36 @@ def test_query_urls(swg_index_client, swg_query_client, test_data):
 
 def test_query_urls_metadata(swg_index_client, swg_query_client, test_data):
     """
+    Test query urls metadata endpoint
     Args:
-        swg_index_client (swagger_client.api.indexurls_api.IndexApi):
+        swg_index_client (swagger_client.api.indexurls_api.IndexApi): index api client
         swg_query_client (swagger_client.api.indexurls_api.IndexurlsApi): urls api client
-        test_data (tuple[int, int, int]:
+        test_data (tuple[int, int, int, int]: test data counts
     """
-    url_x_count, _, unversioned_count = test_data
+    url_x_count, versioned_count, unversioned_count, deleted_count = test_data
+
     # test get all
     urls_list = swg_query_client.query_urls_metadata(key="state", value="uploaded", url="awesome-x")
     assert len(urls_list) == 2 * url_x_count
 
     # test list versioned urls
-    urls_list = swg_query_client.query_urls_metadata(key="state", value="uploaded",
-                                                     url="awesome-x", versioned=True)
+    urls_list = swg_query_client.query_urls_metadata(key="state", value="uploaded", url="awesome-x", versioned=True)
     assert len(urls_list) == url_x_count
 
     # test list un versioned
     urls_list = swg_query_client.query_urls_metadata(key="state", value="uploaded", url="endpointurl", versioned=False)
     assert len(urls_list) == unversioned_count
 
+    # test deleted
+    urls_list = swg_query_client.query_urls_metadata(
+        key="state", value="uploaded", url="endpointurl", not_deleted=False
+    )
+    assert len(urls_list) == deleted_count + versioned_count + unversioned_count
+
     # test unknown state
     urls_list = swg_query_client.query_urls_metadata(key="state", value="uploadedx", url="awesome-x")
     assert len(urls_list) == 0
+
 
 def test_status(client):
     resp = client.get("/_status")


### PR DESCRIPTION
This request includes the following changes:

- Add not_deleted flag to the query urls endpoints (get_query_urls and get_query_urls_metadata)
- Add updated params to the openapi documentation
- Update versioned flag parameters in openapi document to not provide a default value since True, False and None are all valid