### PR TITLE
Fix Openapi spec: add fields param to query urls

### DIFF
--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -956,7 +956,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/URLsOutput'
+                $ref: '#/components/schemas/URLsMetadataOutput'
         400:
           description: invalid request parameters
           content: {}
@@ -1444,6 +1444,15 @@ components:
             type: array
             items:
               type: string
+    URLsMetadataOutput:
+        allOf:
+         - $ref: '#/components/schemas/URLsOutput'
+         - type: array
+         - items:
+            type: object
+            properties:
+             rev:
+                type: string
     SystemMetadata:
       type: object
       description: |-

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -878,6 +878,12 @@ paths:
         schema:
           type: integer
           default: 0
+      - name: fields
+        in: query
+        description: Comma separated list (defaults to did,urls) of fields to return
+        schema:
+          type: string
+          default: urls,did
       responses:
         200:
           description: successful
@@ -938,6 +944,12 @@ paths:
         schema:
           type: integer
           default: 0
+      - name: fields
+        in: query
+        description: Comma separated list (defaults to did,urls,rev) of fields to return
+        schema:
+          type: string
+          default: urls,did,rev
       responses:
         200:
           description: successful

--- a/openapis/swagger.yaml
+++ b/openapis/swagger.yaml
@@ -880,7 +880,7 @@ paths:
           default: 0
       - name: fields
         in: query
-        description: Comma separated list (defaults to did,urls) of fields to return
+        description: Comma separated list (defaults to did,urls) of fields to return. Valid fields are did and urls.
         schema:
           type: string
           default: urls,did
@@ -946,7 +946,7 @@ paths:
           default: 0
       - name: fields
         in: query
-        description: Comma separated list (defaults to did,urls,rev) of fields to return
+        description: Comma separated list (defaults to did,urls,rev) of fields to return. Valid fields are did, urls and rev.
         schema:
           type: string
           default: urls,did,rev


### PR DESCRIPTION
* `fields` query param was missing from the openapi spec of urls query paths( /_query/urls/q and /_query/urls/metadata/q  ). Added `fields` to those paths. 
* Updated response schema of `/_query/urls/metadata/q` to include `rev`. 