### PR TITLE
Ddtrace not patch graphql

### DIFF
--- a/indexd/app.py
+++ b/indexd/app.py
@@ -15,7 +15,7 @@ from .index.blueprint import blueprint as indexd_index_blueprint
 
 def app_init(app, settings=None):
     app.logger.addHandler(cdislogging.get_stream_handler())
-    ddtrace.patch_all()
+    ddtrace.patch(graphql=False)
     if not settings:
         from .default_settings import settings
     app.config.update(settings["config"])

--- a/indexd/app.py
+++ b/indexd/app.py
@@ -15,6 +15,10 @@ from .index.blueprint import blueprint as indexd_index_blueprint
 
 def app_init(app, settings=None):
     app.logger.addHandler(cdislogging.get_stream_handler())
+    # TODO: When indexd is used by gdcapi (as dev dep during tests),
+    # ddtrace patches graphql because of patch_all(). To prevent that
+    # we explicitly excluded. At any rate, graphql is NOT used by
+    # indexd so it's safe to disable it.
     ddtrace.patch_all(graphql=False)
     if not settings:
         from .default_settings import settings

--- a/indexd/app.py
+++ b/indexd/app.py
@@ -15,7 +15,7 @@ from .index.blueprint import blueprint as indexd_index_blueprint
 
 def app_init(app, settings=None):
     app.logger.addHandler(cdislogging.get_stream_handler())
-    ddtrace.patch(flask=True, psycopg=True, sqlalchemy=True)
+    ddtrace.patch_all(grapqh=False)
     if not settings:
         from .default_settings import settings
     app.config.update(settings["config"])

--- a/indexd/app.py
+++ b/indexd/app.py
@@ -15,7 +15,7 @@ from .index.blueprint import blueprint as indexd_index_blueprint
 
 def app_init(app, settings=None):
     app.logger.addHandler(cdislogging.get_stream_handler())
-    ddtrace.patch_all(grapqh=False)
+    ddtrace.patch_all(graphql=False)
     if not settings:
         from .default_settings import settings
     app.config.update(settings["config"])

--- a/indexd/app.py
+++ b/indexd/app.py
@@ -15,7 +15,7 @@ from .index.blueprint import blueprint as indexd_index_blueprint
 
 def app_init(app, settings=None):
     app.logger.addHandler(cdislogging.get_stream_handler())
-    ddtrace.patch(graphql=False)
+    ddtrace.patch(flask=True, psycopg=True, sqlalchemy=True)
     if not settings:
         from .default_settings import settings
     app.config.update(settings["config"])


### PR DESCRIPTION
Prevent ddtrace from patching all.
    
    Do not patch all. Prevent graphql from being patched.
    When grapqhl is patched and indexd as dev dependency is
    used by gdcapi, gdcapi tests fail because gdcapi's graphql
    gets patched.
