### PR TITLE
DEV-2841: Pin ddtrace to prevent reintroducing POAM vulnerability

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "psycopg2>=2.7",
         "cdislogging>=1.0",
         "requests",
-        "ddtrace",
+        "ddtrace>=2.9.1",
         "importlib-metadata>=1.4; python_version < '3.8'",
         # jsonschema-spec 0.1.6 depends on typing-extensions<4.6.0
         "typing-extensions<4.6.0",


### PR DESCRIPTION
In a previous change, ddtrace was upgraded to v2.9.2 to fix a security vulnerability specified in the POAM. That change, however, neglected to pin a min version (specifically v2.9.1) to prevent reintroduction of the vulnerability due to a reversion. This change fixes that concern.

As part of testing, the ddtrace dependency was removed from the requirements.txt file and pip-compile was re-run. The correct version (i.e. v2.9.2) was added back to the file. Thus, the setup.py file has been updated and tested but there is no corresponding update to requirements.txt because v2.9.2 is still the latest/correct version.