### PR TITLE
DEV-2842: Fix zipp vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -89,7 +89,8 @@ wrapt==1.16.0
     # via deprecated
 xmltodict==0.13.0
     # via ddtrace
-zipp==3.15.0
+zipp==3.20.1
     # via
     #   importlib-metadata
     #   importlib-resources
+    #   indexd (setup.py)

--- a/setup.py
+++ b/setup.py
@@ -45,10 +45,11 @@ setup(
         "sqlalchemy-utils>=0.32",
         "psycopg2>=2.7",
         "cdislogging>=1.0",
-        "requests>=2.32.2",
+        "requests>=2.32.2",  # pinned for DEV-2844 (POAM)
         "ddtrace>=2.9.1",
         "importlib-metadata>=1.4",
         # jsonschema-spec 0.1.6 depends on typing-extensions<4.6.0
         "typing-extensions<4.6.0",
+        "zipp>=3.19.1",  # pinned for DEV-2842 (POAM)
     ],
 )


### PR DESCRIPTION
POAM. This mitigates the following zipp vulnerability: [SNYK-PYTHON-ZIPP-7430899](https://security.snyk.io/vuln/SNYK-PYTHON-ZIPP-7430899)