### PR TITLE
DEV-3209: bump jinja version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.0-experimental
 
-ARG BASE_VERSION=3.1.0
+ARG BASE_VERSION=3.0.9
 ARG REGISTRY=docker.osdc.io
 ARG SERVICE_NAME=indexd
 ARG PYTHON_VERSION=python3.8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.0-experimental
 
-ARG BASE_VERSION=3.0.7
+ARG BASE_VERSION=3.0.9
 ARG REGISTRY=docker.osdc.io
 ARG SERVICE_NAME=indexd
 ARG PYTHON_VERSION=python3.8
@@ -34,9 +34,8 @@ LABEL org.opencontainers.image.title="${SERVICE_NAME}" \
       org.opencontainers.image.revision="${COMMIT}" \
       org.opencontainers.image.created="${BUILD_DATE}"
 
-RUN dnf install -y libpq-15.0
-
-RUN mkdir -p /var/www/${SERVICE_NAME}/ \
+RUN dnf install -y libpq-15.0 && \
+    mkdir -p /var/www/${SERVICE_NAME}/ \
   && chmod 777 /var/www/${SERVICE_NAME}
 
 COPY wsgi.py /var/www/${SERVICE_NAME}/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.0-experimental
 
-ARG BASE_VERSION=3.0.9
+ARG BASE_VERSION=3.1.0
 ARG REGISTRY=docker.osdc.io
 ARG SERVICE_NAME=indexd
 ARG PYTHON_VERSION=python3.8
@@ -34,9 +34,9 @@ LABEL org.opencontainers.image.title="${SERVICE_NAME}" \
       org.opencontainers.image.revision="${COMMIT}" \
       org.opencontainers.image.created="${BUILD_DATE}"
 
-RUN dnf install -y libpq-15.0 && \
-    mkdir -p /var/www/${SERVICE_NAME}/ \
-  && chmod 777 /var/www/${SERVICE_NAME}
+RUN dnf install -y libpq-15.0 \
+    && mkdir -p /var/www/${SERVICE_NAME}/ \
+    && chmod 777 /var/www/${SERVICE_NAME}
 
 COPY wsgi.py /var/www/${SERVICE_NAME}/
 COPY .docker/indexd.conf /etc/httpd/conf.d/indexd.conf

--- a/indexd/index/schema.py
+++ b/indexd/index/schema.py
@@ -1,5 +1,5 @@
 POST_RECORD_SCHEMA = {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "additionalProperties": False,
     "description": "Create a new index from hash & size",
@@ -70,7 +70,7 @@ POST_RECORD_SCHEMA = {
 }
 
 PUT_RECORD_SCHEMA = {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "additionalProperties": False,
     "description": "Update an index",

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ jinja2==3.1.5
     # via flask
 jsonschema==4.23.0
     # via indexd (setup.py)
-jsonschema-specifications==2023.12.1
+jsonschema-specifications==2023.7.1
     # via jsonschema
 markupsafe==2.1.5
     # via
@@ -61,8 +61,9 @@ protobuf==5.29.3
     # via ddtrace
 psycopg2==2.9.10
     # via indexd (setup.py)
-referencing==0.35.1
+referencing==0.30.2
     # via
+    #   indexd (setup.py)
     #   jsonschema
     #   jsonschema-specifications
 requests==2.32.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 --index-url https://nexus.osdc.io/repository/pypi-gdc-releases/simple
 
-attrs==24.3.0
+attrs==25.1.0
     # via
     #   jsonschema
     #   referencing
@@ -22,9 +22,9 @@ charset-normalizer==3.4.1
     # via requests
 click==8.1.8
     # via flask
-ddtrace==2.19.1
+ddtrace==2.20.0
     # via indexd (setup.py)
-deprecated==1.2.15
+deprecated==1.2.18
     # via opentelemetry-api
 envier==0.6.1
     # via ddtrace
@@ -37,8 +37,9 @@ importlib-metadata==8.5.0
     #   flask
     #   indexd (setup.py)
     #   opentelemetry-api
-importlib-resources==6.4.5
+importlib-resources==6.1.3
     # via
+    #   indexd (setup.py)
     #   jsonschema
     #   jsonschema-specifications
 itsdangerous==2.2.0
@@ -77,7 +78,7 @@ sqlalchemy==1.3.24
     #   sqlalchemy-utils
 sqlalchemy-utils==0.41.2
     # via indexd (setup.py)
-typing-extensions==4.5.0
+typing-extensions==4.12.2
     # via
     #   bytecode
     #   ddtrace

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ jinja2==3.1.5
     # via flask
 jsonschema==4.23.0
     # via indexd (setup.py)
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.12.1
     # via jsonschema
 markupsafe==2.1.5
     # via
@@ -61,9 +61,8 @@ protobuf==5.29.3
     # via ddtrace
 psycopg2==2.9.10
     # via indexd (setup.py)
-referencing==0.30.2
+referencing==0.35.1
     # via
-    #   indexd (setup.py)
     #   jsonschema
     #   jsonschema-specifications
 requests==2.32.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,70 +6,71 @@
 #
 --index-url https://nexus.osdc.io/repository/pypi-gdc-releases/simple
 
-attrs==23.2.0
+attrs==24.3.0
     # via
-    #   cattrs
-    #   ddtrace
     #   jsonschema
-bytecode==0.13.0
-    # via ddtrace
-cattrs==23.1.2
+    #   referencing
+blinker==1.8.2
+    # via flask
+bytecode==0.16.1
     # via ddtrace
 cdislogging==1.1.1
     # via indexd (setup.py)
-certifi==2024.7.4
+certifi==2024.12.14
     # via requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.1
     # via requests
-click==8.1.7
+click==8.1.8
     # via flask
-ddsketch==3.0.1
-    # via ddtrace
-ddtrace==2.9.2
+ddtrace==2.19.1
     # via indexd (setup.py)
-deprecated==1.2.14
+deprecated==1.2.15
     # via opentelemetry-api
-envier==0.5.1
+envier==0.6.1
     # via ddtrace
-exceptiongroup==1.2.1
-    # via cattrs
-flask==2.2.5
+flask==3.0.3
     # via indexd (setup.py)
-idna==3.7
+idna==3.10
     # via requests
-importlib-metadata==6.11.0
+importlib-metadata==8.5.0
     # via
     #   flask
     #   indexd (setup.py)
     #   opentelemetry-api
-importlib-resources==5.12.0
-    # via jsonschema
-itsdangerous==2.1.2
+importlib-resources==6.4.5
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
+itsdangerous==2.2.0
     # via flask
-jinja2==3.1.4
+jinja2==3.1.5
     # via flask
-jsonschema==4.17.3
+jsonschema==4.23.0
     # via indexd (setup.py)
+jsonschema-specifications==2023.12.1
+    # via jsonschema
 markupsafe==2.1.5
     # via
     #   jinja2
     #   werkzeug
-opentelemetry-api==1.22.0
+opentelemetry-api==1.29.0
     # via ddtrace
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-protobuf==4.24.4
+protobuf==5.29.3
     # via ddtrace
-psycopg2==2.9.9
+psycopg2==2.9.10
     # via indexd (setup.py)
-pyrsistent==0.19.3
-    # via jsonschema
+referencing==0.35.1
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.32.3
     # via indexd (setup.py)
-six==1.16.0
+rpds-py==0.20.1
     # via
-    #   ddsketch
-    #   ddtrace
+    #   jsonschema
+    #   referencing
 sqlalchemy==1.3.24
     # via
     #   indexd (setup.py)
@@ -78,20 +79,22 @@ sqlalchemy-utils==0.41.2
     # via indexd (setup.py)
 typing-extensions==4.5.0
     # via
-    #   cattrs
+    #   bytecode
     #   ddtrace
     #   indexd (setup.py)
-urllib3==2.0.7
+urllib3==2.2.3
     # via requests
 werkzeug==3.0.6
     # via
     #   flask
     #   indexd (setup.py)
-wrapt==1.16.0
-    # via deprecated
-xmltodict==0.13.0
+wrapt==1.17.2
+    # via
+    #   ddtrace
+    #   deprecated
+xmltodict==0.14.2
     # via ddtrace
-zipp==3.20.1
+zipp==3.20.2
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,6 @@ setup(
     ],
     python_requires=">=3.8",
     packages=find_packages(),
-    package_data={
-        "index": [
-            "schemas/*",
-        ]
-    },
     scripts=["bin/index_admin.py", "bin/indexd", "bin/migrate_index.py"],
     extras_require={
         "dev": [
@@ -35,12 +30,12 @@ setup(
             "pytest-flask",
             "PyYAML",
             "openapi-spec-validator",
-            "jsonschema-path>=0.3.1",  # previously jsonschema-spec project migrated to jsonschema-path after 0.2.4
         ],
     },
     install_requires=[
         "flask>=2.2",
-        "jsonschema>3",
+        "jsonschema>4.17",
+        "importlib_resources<6.2",  # >=6.2 fails for py38 but works ok for 39+
         "sqlalchemy<1.4",  # TODO: Unpin sqlalchemy. Pinning is only required when psqlgraph is involved.
         "sqlalchemy-utils>=0.32",
         "psycopg2>=2.7",
@@ -48,7 +43,7 @@ setup(
         "requests>=2.32.2",
         "ddtrace>=2.9.1",
         "importlib-metadata>=1.4",
-        "typing-extensions<4.6.0",
+        "typing-extensions",
         "zipp>=3.19.1",
         "werkzeug>=3.0.6",
     ],

--- a/setup.py
+++ b/setup.py
@@ -35,12 +35,11 @@ setup(
             "pytest-flask",
             "PyYAML",
             "openapi-spec-validator",
-            "jsonschema-spec==0.2.4",  # project migrated to jsonschema-path after 0.2.4
+            "jsonschema-path>=0.3.1",  # previously jsonschema-spec project migrated to jsonschema-path after 0.2.4
         ],
     },
     install_requires=[
         "flask>=2.2",
-        "referencing<0.31.0,>=0.28.0",
         "jsonschema>3",
         "sqlalchemy<1.4",  # TODO: Unpin sqlalchemy. Pinning is only required when psqlgraph is involved.
         "sqlalchemy-utils>=0.32",

--- a/setup.py
+++ b/setup.py
@@ -35,11 +35,12 @@ setup(
             "pytest-flask",
             "PyYAML",
             "openapi-spec-validator",
-            "jsonschema-spec>=0.1.6",  # used by openapi-spec-validator and have bug in 0.1.4
+            "jsonschema-spec==0.2.4",  # project migrated to jsonschema-path after 0.2.4
         ],
     },
     install_requires=[
         "flask>=2.2",
+        "referencing<0.31.0,>=0.28.0",
         "jsonschema>3",
         "sqlalchemy<1.4",  # TODO: Unpin sqlalchemy. Pinning is only required when psqlgraph is involved.
         "sqlalchemy-utils>=0.32",
@@ -48,7 +49,6 @@ setup(
         "requests>=2.32.2",
         "ddtrace>=2.9.1",
         "importlib-metadata>=1.4",
-        # jsonschema-spec 0.1.6 depends on typing-extensions<4.6.0
         "typing-extensions<4.6.0",
         "zipp>=3.19.1",
         "werkzeug>=3.0.6",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -156,9 +156,10 @@ def indexd_server():
     port = INDEXD_TEST_PORT
     debug = False
     t = threading.Thread(
-        target=app.run, kwargs={"host": hostname, "port": port, "debug": debug}
+        target=app.run,
+        daemon=True,
+        kwargs={"host": hostname, "port": port, "debug": debug},
     )
-    t.setDaemon(True)
     t.start()
     wait_for_indexd_alive(port)
     yield MockServer(port=port)

--- a/tests/unit/test_openapi.py
+++ b/tests/unit/test_openapi.py
@@ -26,4 +26,4 @@ def test_valid_openapi():
         # ensure the spec is valid JSON
         spec = json.loads(json.dumps(spec))
 
-        openapi_spec_validator.validate_spec(spec, url)
+        openapi_spec_validator.validate(spec, url)

--- a/tests/unit/test_openapi.py
+++ b/tests/unit/test_openapi.py
@@ -1,7 +1,14 @@
 import json
 
+try:
+    from importlib.resources import as_file, files
+except ImportError:
+    from importlib_resources import (  # type: ignore[import-not-found, no-redef]
+        files,
+        as_file,
+    )
+
 import openapi_spec_validator
-import pkg_resources
 from openapi_spec_validator import exceptions as specs_exceptions
 from openapi_spec_validator import readers as specs_readers
 
@@ -9,12 +16,14 @@ import openapis
 
 
 def test_valid_openapi():
-    filename = pkg_resources.resource_filename(openapis.__name__, "swagger.yaml")
-    spec, url = specs_readers.read_from_filename(filename)
+    with as_file(files(openapis.__name__).joinpath("swagger.yaml")) as filename:
+        spec, url = specs_readers.read_from_filename(filename)
 
-    if not isinstance(spec, dict):
-        raise specs_exceptions.OpenAPIValidationError("root node is not a mapping")
-    # ensure the spec is valid JSON
-    spec = json.loads(json.dumps(spec))
+        if not isinstance(spec, dict):
+            raise specs_exceptions.OpenAPISpecValidatorError(
+                "root node is not a mapping"
+            )
+        # ensure the spec is valid JSON
+        spec = json.loads(json.dumps(spec))
 
-    openapi_spec_validator.validate_spec(spec, url)
+        openapi_spec_validator.validate_spec(spec, url)


### PR DESCRIPTION
- Resolve POAM DEV-3209 and 3210
- fix deprecation warnings for openapi spec validator and json schema validation
- pin importlib resources as 6.2 - 6.4.5 causes failures for jsonschema and referencing libraries (this works fine for py39+)