### PR TITLE
DEV-3362: upgrade to sqlalchemy 2+

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -134,7 +134,7 @@
         "filename": "tests/integration/conftest.py",
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_verified": false,
-        "line_number": 86,
+        "line_number": 87,
         "is_secret": false
       }
     ],
@@ -247,5 +247,5 @@
       }
     ]
   },
-  "generated_at": "2025-03-13T17:55:47Z"
+  "generated_at": "2025-04-14T19:01:58Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -134,7 +134,7 @@
         "filename": "tests/integration/conftest.py",
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_verified": false,
-        "line_number": 87,
+        "line_number": 86,
         "is_secret": false
       }
     ],
@@ -242,10 +242,10 @@
         "filename": "tests/integration/test_schema_migration.py",
         "hashed_secret": "5666c088b494f26cd8f63ace013992f5fc391ce0",
         "is_verified": false,
-        "line_number": 80,
+        "line_number": 81,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2025-04-14T19:01:58Z"
+  "generated_at": "2025-04-15T03:06:18Z"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,13 +36,8 @@ source = ["indexd"]
 minversion = 6.0
 python_files = "test_*.py"
 python_functions = "test_*"
-# Silence warning by opting in to use pytest 6's new default value
-junit_family = "xunit2"
-junit_logging = "system-out"
-console_output_style = "classic"
 log_cli_level = "INFO"
-log_level = "INFO"
-log_cli = "true"
+log_cli = "1"
 log_auto_indent = "true"
 addopts = [
   "-rvlFE --color=true -p no:ddtrace -p no:ddtrace.pytest_bdd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,12 @@ testpaths = [
   "tests/unit",
   "tests/integration"
 ]
+env = [
+  "SQLALCHEMY_WARN_20=1",
+  "LOGSTICK_LOG_LEVEL=debug",
+  "LOGSTICK_ROOT_LOG_LEVEL=info",
+  "LOGSTICK_OUTPUT_FORMAT=raw"
+]
 
 [tool.ruff]
 line-length = 88 # black's default

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,8 +63,8 @@ testpaths = [
 env = [
   "SQLALCHEMY_WARN_20=1",
   "LOGSTICK_LOG_LEVEL=debug",
-  "LOGSTICK_ROOT_LOG_LEVEL=info",
-  "LOGSTICK_OUTPUT_FORMAT=raw"
+  "LOGSTICK_OUTPUT_FORMAT=raw",
+  "LOGSTICK_ROOT_LOG_LEVEL=info"
 ]
 
 [tool.ruff]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ attrs==25.3.0
     #   referencing
 blinker==1.9.0
     # via flask
-bytecode==0.16.1
+bytecode==0.16.2
     # via ddtrace
 certifi==2025.1.31
     # via requests
@@ -24,22 +24,22 @@ colorama==0.4.6
     # via logstick
 colorlog==6.9.0
     # via logstick
-ddtrace==3.2.1
+ddtrace==3.4.1
     # via indexd (pyproject.toml)
 deprecated==1.2.18
-    # via opentelemetry-api
+    # via
+    #   logstick
+    #   opentelemetry-api
 envier==0.6.1
     # via ddtrace
 flask==3.1.0
     # via indexd (pyproject.toml)
+greenlet==3.1.1
+    # via sqlalchemy
 idna==3.10
     # via requests
 importlib-metadata==8.6.1
-    # via
-    #   indexd (pyproject.toml)
-    #   opentelemetry-api
-importlib-resources==6.1.3
-    # via indexd (pyproject.toml)
+    # via opentelemetry-api
 itsdangerous==2.2.0
     # via flask
 jinja2==3.1.6
@@ -48,9 +48,9 @@ jsonschema==4.23.0
     # via indexd (pyproject.toml)
 jsonschema-specifications==2024.10.1
     # via jsonschema
-legacy-cgi==2.6.2
+legacy-cgi==2.6.3
     # via ddtrace
-logstick==0.1.3
+logstick==0.1.4
     # via indexd (pyproject.toml)
 markdown-it-py==3.0.0
     # via rich
@@ -60,9 +60,9 @@ markupsafe==3.0.2
     #   werkzeug
 mdurl==0.1.2
     # via markdown-it-py
-opentelemetry-api==1.31.0
+opentelemetry-api==1.32.0
     # via ddtrace
-protobuf==6.30.0
+protobuf==6.30.2
     # via ddtrace
 psycopg2==2.9.10
     # via indexd (pyproject.toml)
@@ -74,13 +74,13 @@ referencing==0.36.2
     #   jsonschema-specifications
 requests==2.32.3
     # via indexd (pyproject.toml)
-rich==13.9.4
+rich==14.0.0
     # via logstick
-rpds-py==0.23.1
+rpds-py==0.24.0
     # via
     #   jsonschema
     #   referencing
-sqlalchemy==1.3.24
+sqlalchemy==2.0.40
     # via
     #   indexd (pyproject.toml)
     #   sqlalchemy-utils
@@ -88,11 +88,12 @@ sqlalchemy-utils==0.41.2
     # via indexd (pyproject.toml)
 structlog==25.2.0
     # via logstick
-typing-extensions==4.12.2
+typing-extensions==4.13.2
     # via
     #   ddtrace
     #   indexd (pyproject.toml)
-urllib3==2.3.0
+    #   sqlalchemy
+urllib3==2.4.0
     # via requests
 werkzeug==3.1.3
     # via

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,14 +28,12 @@ include_package_data = True
 install_requires =
     flask>=2.2
     jsonschema>4.17
-    importlib_resources<6.2  # TODO: >=6.2 fails for py38 but works ok for 39+
-    logstick
-    sqlalchemy<1.4  # TODO: Unpin sqlalchemy. Pinning is only required when psqlgraph is involved.
+    logstick>=0.1.4
+    sqlalchemy>=1.4
     sqlalchemy-utils>=0.32
     psycopg2>=2.7
     requests>=2.32.2
     ddtrace>=2.9.1
-    importlib-metadata>=1.4
     typing-extensions
     zipp>=3.19.1
     werkzeug>=3.0.6

--- a/src/indexd/__init__.py
+++ b/src/indexd/__init__.py
@@ -1,7 +1,10 @@
 from importlib.metadata import distribution
 
 import logstick
+from ddtrace import auto  # noqa
 
-logstick.configure_logging(namespace=__name__, disable_existing_loggers=False)
+logstick.configure_logging(
+    namespace=__name__, disable_existing_loggers=False, extra_namespaces=["werkzeug"]
+)
 __distribution = distribution(__name__)
 VERSION = __distribution.version

--- a/src/indexd/alias/drivers/alchemy.py
+++ b/src/indexd/alias/drivers/alchemy.py
@@ -2,8 +2,8 @@ import logging
 import uuid
 from contextlib import contextmanager
 
-import sqlalchemy
-from sqlalchemy import BigInteger, Column, ForeignKey, Integer, String, and_, exc, orm
+import sqlalchemy as sa
+from sqlalchemy import exc, orm
 
 from indexd.alias.driver import AliasDriverABC
 from indexd.alias.errors import (
@@ -15,7 +15,7 @@ from indexd.index.errors import UnhealthyCheckError
 from indexd.utils import init_schema_version, is_empty_database, migrate_database
 
 logger = logging.getLogger(__name__)
-Base = sqlalchemy.orm.declarative_base()
+Base = orm.declarative_base()
 
 
 class AliasSchemaVersion(Base):
@@ -24,7 +24,7 @@ class AliasSchemaVersion(Base):
     """
 
     __tablename__ = "alias_schema_version"
-    version = Column(Integer, primary_key=True)
+    version: orm.Mapped[int] = sa.Column(sa.Integer, primary_key=True)
 
 
 class AliasRecord(Base):
@@ -34,26 +34,26 @@ class AliasRecord(Base):
 
     __tablename__ = "alias_record"
 
-    name = Column(String, primary_key=True)
-    rev = Column(String)
-    size = Column(BigInteger)
+    name: orm.Mapped[str] = sa.Column(sa.String, primary_key=True)
+    rev: orm.Mapped[str] = sa.Column(sa.String)
+    size: orm.Mapped[int] = sa.Column(sa.BigInteger)
 
-    hashes = orm.relationship(
+    hashes: orm.Mapped[list["AliasRecordHash"]] = orm.relationship(
         "AliasRecordHash",
-        backref="alias_record",
+        back_populates="alias_record",
         cascade="all, delete-orphan",
     )
 
-    release = Column(String)
-    metastring = Column(String)
+    release: orm.Mapped[str] = sa.Column(sa.String)
+    metastring: orm.Mapped[str] = sa.Column(sa.String)
 
-    host_authorities = orm.relationship(
+    host_authorities: orm.Mapped[list["AliasRecordHostAuthority"]] = orm.relationship(
         "AliasRecordHostAuthority",
-        backref="alias_record",
+        back_populates="alias_record",
         cascade="all, delete-orphan",
     )
 
-    keeper_authority = Column(String)
+    keeper_authority: orm.Mapped[str] = sa.Column(sa.String)
 
 
 class AliasRecordHash(Base):
@@ -63,9 +63,13 @@ class AliasRecordHash(Base):
 
     __tablename__ = "alias_record_hash"
 
-    name = Column(String, ForeignKey("alias_record.name"), primary_key=True)
-    hash_type = Column(String, primary_key=True)
-    hash_value = Column(String)
+    name: orm.Mapped[str] = sa.Column(
+        sa.String, sa.ForeignKey("alias_record.name"), primary_key=True
+    )
+    hash_type: orm.Mapped[str] = sa.Column(sa.String, primary_key=True)
+    hash_value: orm.Mapped[str] = sa.Column(sa.String)
+
+    alias_record: orm.Mapped[AliasRecord] = orm.relationship(back_populates="hashes")
 
 
 class AliasRecordHostAuthority(Base):
@@ -75,8 +79,14 @@ class AliasRecordHostAuthority(Base):
 
     __tablename__ = "alias_record_host_authority"
 
-    name = Column(String, ForeignKey("alias_record.name"), primary_key=True)
-    host = Column(String, primary_key=True)
+    name: orm.Mapped[str] = sa.Column(
+        sa.String, sa.ForeignKey("alias_record.name"), primary_key=True
+    )
+    host: orm.Mapped[str] = sa.Column(sa.String, primary_key=True)
+
+    alias_record: orm.Mapped[AliasRecord] = orm.relationship(
+        back_populates="host_authorities"
+    )
 
 
 class SQLAlchemyAliasDriver(AliasDriverABC):
@@ -121,7 +131,7 @@ class SQLAlchemyAliasDriver(AliasDriverABC):
         """
         with self.session as session:
             try:
-                session.execute(sqlalchemy.text("SELECT 1"))
+                session.execute(sa.text("SELECT 1"))
             except Exception:
                 raise UnhealthyCheckError()
 
@@ -160,7 +170,7 @@ class SQLAlchemyAliasDriver(AliasDriverABC):
             if hashes is not None:
                 for h, v in hashes.items():
                     subq = session.query(AliasRecordHash.name).filter(
-                        and_(
+                        sa.and_(
                             AliasRecordHash.hash_type == h,
                             AliasRecordHash.hash_value == v,
                         )
@@ -326,7 +336,7 @@ class SQLAlchemyAliasDriver(AliasDriverABC):
 
 def migrate_1(session, **kwargs):
     session.execute(
-        sqlalchemy.text(
+        sa.text(
             f"ALTER TABLE {AliasRecord.__tablename__} ALTER COLUMN size TYPE bigint"
         )
     )

--- a/src/indexd/alias/drivers/alchemy.py
+++ b/src/indexd/alias/drivers/alchemy.py
@@ -2,10 +2,8 @@ import logging
 import uuid
 from contextlib import contextmanager
 
-from sqlalchemy import BigInteger, Column, ForeignKey, Integer, String, and_
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import relationship, sessionmaker
-from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
+import sqlalchemy
+from sqlalchemy import BigInteger, Column, ForeignKey, Integer, String, and_, exc, orm
 
 from indexd.alias.driver import AliasDriverABC
 from indexd.alias.errors import (
@@ -17,7 +15,7 @@ from indexd.index.errors import UnhealthyCheckError
 from indexd.utils import init_schema_version, is_empty_database, migrate_database
 
 logger = logging.getLogger(__name__)
-Base = declarative_base()
+Base = sqlalchemy.orm.declarative_base()
 
 
 class AliasSchemaVersion(Base):
@@ -40,7 +38,7 @@ class AliasRecord(Base):
     rev = Column(String)
     size = Column(BigInteger)
 
-    hashes = relationship(
+    hashes = orm.relationship(
         "AliasRecordHash",
         backref="alias_record",
         cascade="all, delete-orphan",
@@ -49,7 +47,7 @@ class AliasRecord(Base):
     release = Column(String)
     metastring = Column(String)
 
-    host_authorities = relationship(
+    host_authorities = orm.relationship(
         "AliasRecordHostAuthority",
         backref="alias_record",
         cascade="all, delete-orphan",
@@ -92,10 +90,10 @@ class SQLAlchemyAliasDriver(AliasDriverABC):
         """
         super().__init__(conn, **config)
         Base.metadata.bind = self.engine
-        self.Session = sessionmaker(bind=self.engine)
+        self.Session = orm.sessionmaker(bind=self.engine)
 
         is_empty_db = is_empty_database(driver=self)
-        Base.metadata.create_all()
+        Base.metadata.create_all(bind=self.engine)
         if is_empty_db:
             init_schema_version(
                 driver=self,
@@ -123,7 +121,7 @@ class SQLAlchemyAliasDriver(AliasDriverABC):
         """
         with self.session as session:
             try:
-                session.execute("SELECT 1")
+                session.execute(sqlalchemy.text("SELECT 1"))
             except Exception:
                 raise UnhealthyCheckError()
 
@@ -195,9 +193,9 @@ class SQLAlchemyAliasDriver(AliasDriverABC):
 
             try:
                 record = query.one()
-            except NoResultFound:
+            except exc.NoResultFound:
                 record = AliasRecord()
-            except MultipleResultsFound:
+            except exc.MultipleResultsFound:
                 raise MultipleRecordsFoundError("multiple records found")
 
             record.name = name
@@ -252,9 +250,9 @@ class SQLAlchemyAliasDriver(AliasDriverABC):
 
             try:
                 record = query.one()
-            except NoResultFound:
+            except exc.NoResultFound:
                 raise NoRecordFoundError("no record found")
-            except MultipleResultsFound:
+            except exc.MultipleResultsFound:
                 raise MultipleRecordsFoundError("multiple records found")
 
             rev = record.rev
@@ -289,9 +287,9 @@ class SQLAlchemyAliasDriver(AliasDriverABC):
 
             try:
                 record = query.one()
-            except NoResultFound:
+            except exc.NoResultFound:
                 raise NoRecordFoundError("no record found")
-            except MultipleResultsFound:
+            except exc.MultipleResultsFound:
                 raise MultipleRecordsFoundError("multiple records found")
 
             if rev is not None and rev != record.rev:
@@ -328,7 +326,9 @@ class SQLAlchemyAliasDriver(AliasDriverABC):
 
 def migrate_1(session, **kwargs):
     session.execute(
-        f"ALTER TABLE {AliasRecord.__tablename__} ALTER COLUMN size TYPE bigint"
+        sqlalchemy.text(
+            f"ALTER TABLE {AliasRecord.__tablename__} ALTER COLUMN size TYPE bigint"
+        )
     )
 
 

--- a/src/indexd/app.py
+++ b/src/indexd/app.py
@@ -1,8 +1,8 @@
 import logging
 import os
 import sys
+from typing import Any
 
-import ddtrace
 import flask
 
 from indexd.alias.blueprint import blueprint as indexd_alias_blueprint
@@ -15,7 +15,6 @@ logger = logging.getLogger(__name__)
 
 
 def app_init(app: flask.Flask, settings=None):
-    ddtrace.patch_all()
     if not settings:
         from .default_settings import settings
     app.config.update(settings["config"])
@@ -27,13 +26,14 @@ def app_init(app: flask.Flask, settings=None):
     app.register_blueprint(index_urls_blueprint, url_prefix="/_query/urls")
 
 
-def get_app():
+def get_app(_settings: dict[str, Any] | str | None = None):
     app = flask.Flask(__name__)
 
     if "INDEXD_SETTINGS" in os.environ:
         sys.path.append(os.environ["INDEXD_SETTINGS"])
 
-    settings = None
+    settings = _settings
+
     try:
         from local_settings import settings
     except ImportError:

--- a/src/indexd/auth/drivers/alchemy.py
+++ b/src/indexd/auth/drivers/alchemy.py
@@ -1,14 +1,14 @@
 import hashlib
 from contextlib import contextmanager
 
-import sqlalchemy
+import sqlalchemy as sa
 from sqlalchemy import exc, orm
 
 from indexd.auth.driver import AuthDriverABC
 from indexd.auth.errors import AuthError
 from indexd.index.errors import UnhealthyCheckError
 
-Base = sqlalchemy.orm.declarative_base()
+Base = orm.declarative_base()
 
 
 class AuthRecord(Base):
@@ -18,8 +18,8 @@ class AuthRecord(Base):
 
     __tablename__ = "auth_record"
 
-    username = sqlalchemy.Column(sqlalchemy.String, primary_key=True)
-    password = sqlalchemy.Column(sqlalchemy.String)
+    username: orm.Mapped[str] = sa.Column(sa.String, primary_key=True)
+    password: orm.Mapped[str] = sa.Column(sa.String)
 
 
 class SQLAlchemyAuthDriver(AuthDriverABC):
@@ -90,7 +90,7 @@ class SQLAlchemyAuthDriver(AuthDriverABC):
         """
         with self.session as session:
             try:
-                session.execute(sqlalchemy.text("SELECT 1"))
+                session.execute(sa.text("SELECT 1"))
             except Exception:
                 raise UnhealthyCheckError()
 

--- a/src/indexd/auth/drivers/alchemy.py
+++ b/src/indexd/auth/drivers/alchemy.py
@@ -1,16 +1,14 @@
 import hashlib
 from contextlib import contextmanager
 
-from sqlalchemy import Column, String
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.orm.exc import NoResultFound
+import sqlalchemy
+from sqlalchemy import exc, orm
 
 from indexd.auth.driver import AuthDriverABC
 from indexd.auth.errors import AuthError
 from indexd.index.errors import UnhealthyCheckError
 
-Base = declarative_base()
+Base = sqlalchemy.orm.declarative_base()
 
 
 class AuthRecord(Base):
@@ -20,8 +18,8 @@ class AuthRecord(Base):
 
     __tablename__ = "auth_record"
 
-    username = Column(String, primary_key=True)
-    password = Column(String)
+    username = sqlalchemy.Column(sqlalchemy.String, primary_key=True)
+    password = sqlalchemy.Column(sqlalchemy.String)
 
 
 class SQLAlchemyAuthDriver(AuthDriverABC):
@@ -35,8 +33,8 @@ class SQLAlchemyAuthDriver(AuthDriverABC):
         """
         super().__init__(conn, **config)
         Base.metadata.bind = self.engine
-        Base.metadata.create_all()
-        self.Session = sessionmaker(bind=self.engine)
+        Base.metadata.create_all(bind=self.engine)
+        self._session_class = orm.sessionmaker(bind=self.engine)
 
     @property
     @contextmanager
@@ -44,7 +42,7 @@ class SQLAlchemyAuthDriver(AuthDriverABC):
         """
         Provide a transactional scope around a series of operations.
         """
-        session = self.Session()
+        session = self._session_class()
 
         try:
             yield session
@@ -92,7 +90,7 @@ class SQLAlchemyAuthDriver(AuthDriverABC):
         """
         with self.session as session:
             try:
-                session.execute("SELECT 1")
+                session.execute(sqlalchemy.text("SELECT 1"))
             except Exception:
                 raise UnhealthyCheckError()
 
@@ -113,7 +111,7 @@ class SQLAlchemyAuthDriver(AuthDriverABC):
 
             try:
                 query.one()
-            except NoResultFound:
+            except exc.NoResultFound:
                 raise AuthError("username / password mismatch")
 
         context = {

--- a/src/indexd/driver_base.py
+++ b/src/indexd/driver_base.py
@@ -1,7 +1,8 @@
-import sqlalchemy
+import sqlalchemy as sa
+from sqlalchemy import orm
 from sqlalchemy_utils import create_database, database_exists
 
-Base = sqlalchemy.orm.declarative_base()
+Base = orm.declarative_base()
 
 
 class SQLAlchemyDriverBase:
@@ -13,7 +14,7 @@ class SQLAlchemyDriverBase:
         """
         Initialize the SQLAlchemy database driver.
         """
-        engine = sqlalchemy.create_engine(conn, **config)
+        engine = sa.create_engine(conn, **config)
         if not database_exists(engine.url):
             create_database(engine.url)
         self.engine = engine

--- a/src/indexd/driver_base.py
+++ b/src/indexd/driver_base.py
@@ -1,8 +1,7 @@
-from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
+import sqlalchemy
 from sqlalchemy_utils import create_database, database_exists
 
-Base = declarative_base()
+Base = sqlalchemy.orm.declarative_base()
 
 
 class SQLAlchemyDriverBase:
@@ -14,7 +13,7 @@ class SQLAlchemyDriverBase:
         """
         Initialize the SQLAlchemy database driver.
         """
-        engine = create_engine(conn, **config)
+        engine = sqlalchemy.create_engine(conn, **config)
         if not database_exists(engine.url):
             create_database(engine.url)
         self.engine = engine

--- a/src/indexd/index/drivers/alchemy.py
+++ b/src/indexd/index/drivers/alchemy.py
@@ -1,25 +1,18 @@
 import copy
+import datetime
 import logging
 import uuid
 from contextlib import contextmanager
 
-import sqlalchemy
+import sqlalchemy as sa
+from deprecated import deprecated
 from sqlalchemy import (
-    BigInteger,
-    Column,
-    DateTime,
-    ForeignKey,
-    ForeignKeyConstraint,
-    Index,
-    Integer,
-    String,
     and_,
     exc,
     func,
     not_,
     or_,
     orm,
-    select,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 
@@ -34,7 +27,7 @@ from indexd.index.errors import (
 from indexd.utils import init_schema_version, is_empty_database, migrate_database
 
 logger = logging.getLogger(__name__)
-Base = sqlalchemy.orm.declarative_base()
+Base = orm.declarative_base()
 
 
 class BaseVersion(Base):
@@ -49,7 +42,7 @@ class BaseVersion(Base):
 
     __tablename__ = "base_version"
 
-    baseid = Column(String, primary_key=True)
+    baseid: orm.Mapped[str] = sa.Column(sa.String, primary_key=True)
 
 
 class IndexSchemaVersion(Base):
@@ -58,7 +51,7 @@ class IndexSchemaVersion(Base):
     """
 
     __tablename__ = "index_schema_version"
-    version = Column(Integer, default=0, primary_key=True)
+    version: orm.Mapped[int] = sa.Column(sa.Integer, default=0, primary_key=True)
 
 
 class IndexRecord(Base):
@@ -68,41 +61,45 @@ class IndexRecord(Base):
 
     __tablename__ = "index_record"
 
-    did = Column(String, primary_key=True)
+    did: orm.Mapped[str] = sa.Column(sa.String, primary_key=True)
 
-    baseid = Column(String, index=True)
-    rev = Column(String)
-    form = Column(String)
-    size = Column(BigInteger, index=True)
-    release_number = Column(String, index=True)
-    created_date = Column(DateTime, server_default=sqlalchemy.text("now()"))
-    updated_date = Column(DateTime, server_default=sqlalchemy.text("now()"))
-    file_name = Column(String, index=True)
-    version = Column(String, index=True)
-    uploader = Column(String, index=True)
-    index_metadata = Column(JSONB)
+    baseid: orm.Mapped[str] = sa.Column(sa.String, index=True)
+    rev: orm.Mapped[str] = sa.Column(sa.String)
+    form: orm.Mapped[str] = sa.Column(sa.String)
+    size: orm.Mapped[int] = sa.Column(sa.BigInteger, index=True)
+    release_number: orm.Mapped[str] = sa.Column(sa.String, index=True)
+    created_date: orm.Mapped[datetime.datetime] = sa.Column(
+        sa.DateTime, server_default=sa.text("now()")
+    )
+    updated_date: orm.Mapped[datetime.datetime] = sa.Column(
+        sa.DateTime, server_default=sa.text("now()")
+    )
+    file_name: orm.Mapped[str] = sa.Column(sa.String, index=True)
+    version: orm.Mapped[str] = sa.Column(sa.String, index=True)
+    uploader: orm.Mapped[str] = sa.Column(sa.String, index=True)
+    index_metadata: orm.Mapped[dict] = sa.Column(JSONB)
 
-    urls_metadata = orm.relationship(
+    urls_metadata: orm.Mapped[list["IndexRecordUrlMetadataJsonb"]] = orm.relationship(
         "IndexRecordUrlMetadataJsonb",
-        backref="index_record",
+        back_populates="index_record",
         cascade="all, delete-orphan",
     )
 
-    acl = orm.relationship(
+    acl: orm.Mapped[list["IndexRecordACE"]] = orm.relationship(
         "IndexRecordACE",
-        backref="index_record",
+        back_populates="index_record",
         cascade="all, delete-orphan",
     )
 
-    hashes = orm.relationship(
+    hashes: orm.Mapped[list["IndexRecordHash"]] = orm.relationship(
         "IndexRecordHash",
-        backref="index_record",
+        back_populates="index_record",
         cascade="all, delete-orphan",
     )
 
-    aliases = orm.relationship(
+    aliases: orm.Mapped[list["IndexRecordAlias"]] = orm.relationship(
         "IndexRecordAlias",
-        backref="index_record",
+        back_populates="index_record",
         cascade="all, delete-orphan",
     )
 
@@ -150,26 +147,30 @@ class IndexRecordAlias(Base):
     """
 
     __tablename__ = "index_record_alias"
-
-    did = Column(String, ForeignKey("index_record.did"), primary_key=True)
-    name = Column(String, primary_key=True)
-
     __table_args__ = (
-        Index("index_record_alias_idx", "did"),
-        Index("index_record_alias_name", "name"),
+        sa.Index("index_record_alias_idx", "did"),
+        sa.Index("index_record_alias_name", "name"),
     )
 
+    did: orm.Mapped[str] = sa.Column(
+        sa.String, sa.ForeignKey("index_record.did"), primary_key=True
+    )
+    name: orm.Mapped[str] = sa.Column(sa.String, primary_key=True)
 
+    index_record: orm.Mapped[IndexRecord] = orm.relationship(back_populates="aliases")
+
+
+@deprecated(reason="Replaced with urls_metadata urls")
 class IndexRecordUrl(Base):
     """
     Base index record url representation.
     """
 
     __tablename__ = "index_record_url"
+    __table_args__ = (sa.Index("index_record_url_idx", "did"),)
 
-    did = Column(String, primary_key=True)
-    url = Column(String, primary_key=True)
-    __table_args__ = (Index("index_record_url_idx", "did"),)
+    did: orm.Mapped[str] = sa.Column(sa.String, primary_key=True)
+    url: orm.Mapped[str] = sa.Column(sa.String, primary_key=True)
 
 
 class IndexRecordACE(Base):
@@ -178,41 +179,46 @@ class IndexRecordACE(Base):
     """
 
     __tablename__ = "index_record_ace"
+    __table_args__ = (sa.Index("index_record_ace_idx", "did"),)
 
-    did = Column(String, ForeignKey("index_record.did"), primary_key=True)
+    did: orm.Mapped[str] = sa.Column(
+        sa.String, sa.ForeignKey("index_record.did"), primary_key=True
+    )
     # access control entry
-    ace = Column(String, primary_key=True)
+    ace: orm.Mapped[str] = sa.Column(sa.String, primary_key=True)
 
-    __table_args__ = (Index("index_record_ace_idx", "did"),)
+    index_record: orm.Mapped[IndexRecord] = orm.relationship(back_populates="acl")
 
 
+@deprecated(reason="Replaced by IndexRecordMetadataJsonb")
 class IndexRecordMetadata(Base):
     """
     Metadata attached to index document
     """
 
     __tablename__ = "index_record_metadata"
-    key = Column(String, primary_key=True)
-    did = Column(String, primary_key=True)
-    value = Column(String)
-    __table_args__ = (Index("index_record_metadata_idx", "did"),)
+    key: orm.Mapped[str] = sa.Column(sa.String, primary_key=True)
+    did: orm.Mapped[str] = sa.Column(sa.String, primary_key=True)
+    value: orm.Mapped[str] = sa.Column(sa.String)
+    __table_args__ = (sa.Index("index_record_metadata_idx", "did"),)
 
 
+@deprecated(reason="Replaced with urls_metadata urls")
 class IndexRecordUrlMetadata(Base):
     """
     Metadata attached to url
     """
 
     __tablename__ = "index_record_url_metadata"
-    key = Column(String, primary_key=True)
-    url = Column(String, primary_key=True)
-    did = Column(String, index=True, primary_key=True)
-    value = Column(String)
+    key = sa.Column(sa.String, primary_key=True)
+    url = sa.Column(sa.String, primary_key=True)
+    did = sa.Column(sa.String, index=True, primary_key=True)
+    value = sa.Column(sa.String)
     __table_args__ = (
-        ForeignKeyConstraint(
+        sa.ForeignKeyConstraint(
             ["did", "url"], ["index_record_url.did", "index_record_url.url"]
         ),
-        Index("index_record_url_metadata_idx", "did"),
+        sa.Index("index_record_url_metadata_idx", "did"),
     )
 
 
@@ -222,12 +228,17 @@ class IndexRecordUrlMetadataJsonb(Base):
     """
 
     __tablename__ = "index_record_url_metadata_jsonb"
-    did = Column(String, primary_key=True)
-    url = Column(String, primary_key=True)
-    type = Column(String, index=True)
-    state = Column(String, index=True)
-    urls_metadata = Column(JSONB)
-    __table_args__ = (ForeignKeyConstraint(["did"], ["index_record.did"]),)
+    __table_args__ = (sa.ForeignKeyConstraint(["did"], ["index_record.did"]),)
+
+    did: orm.Mapped[str] = sa.Column(sa.String, primary_key=True)
+    url: orm.Mapped[str] = sa.Column(sa.String, primary_key=True)
+    type: orm.Mapped[str] = sa.Column(sa.String, index=True)
+    state: orm.Mapped[str] = sa.Column(sa.String, index=True)
+    urls_metadata: orm.Mapped[dict] = sa.Column(JSONB)
+
+    index_record: orm.Mapped[IndexRecord] = orm.relationship(
+        back_populates="urls_metadata"
+    )
 
 
 class IndexRecordHash(Base):
@@ -236,13 +247,18 @@ class IndexRecordHash(Base):
     """
 
     __tablename__ = "index_record_hash"
-    did = Column(String, ForeignKey("index_record.did"), primary_key=True)
-    hash_type = Column(String, primary_key=True)
-    hash_value = Column(String)
     __table_args__ = (
-        Index("index_record_hash_idx", "did"),
-        Index("index_record_hash_type_value_idx", "hash_value", "hash_type"),
+        sa.Index("index_record_hash_idx", "did"),
+        sa.Index("index_record_hash_type_value_idx", "hash_value", "hash_type"),
     )
+
+    did: orm.Mapped[str] = sa.Column(
+        sa.String, sa.ForeignKey("index_record.did"), primary_key=True
+    )
+    hash_type: orm.Mapped[str] = sa.Column(sa.String, primary_key=True)
+    hash_value: orm.Mapped[str] = sa.Column(sa.String)
+
+    index_record: orm.Mapped[IndexRecord] = orm.relationship(back_populates="hashes")
 
 
 def separate_urls_metadata(urls_metadata):
@@ -252,7 +268,7 @@ def separate_urls_metadata(urls_metadata):
     object. To keep backwards compatibility these are still ingested
     through the urls_metadata field. We have to manually separate them and
     later combine them to maintain compatibility with the current indexclient.
-    """
+    m"""
     urls_metadata = copy.deepcopy(urls_metadata)
 
     # If these fields are given, then remove them from the json
@@ -1149,7 +1165,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
         """
         with self.session as session:
             try:
-                session.execute(sqlalchemy.text("SELECT 1"))
+                session.execute(sa.text("SELECT 1"))
             except Exception:
                 raise UnhealthyCheckError()
 
@@ -1190,7 +1206,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
         """
         with self.session as session:
             return session.execute(
-                select([func.count()]).select_from(IndexRecord)
+                sa.select([func.count()]).select_from(IndexRecord)
             ).scalar()
 
 
@@ -1218,9 +1234,7 @@ def extract_urls_metadata(urls_metadata_results):
 # change to a model is made, one or more migration steps might not work.
 # In the future consider using SQL queries to do the migrations.
 def migrate_1(session, **kwargs):
-    session.execute(
-        sqlalchemy.text("ALTER TABLE index_record ALTER COLUMN size TYPE bigint")
-    )
+    session.execute(sa.text("ALTER TABLE index_record ALTER COLUMN size TYPE bigint"))
 
 
 def migrate_2(session, **kwargs):
@@ -1229,7 +1243,7 @@ def migrate_2(session, **kwargs):
     """
     try:
         session.execute(
-            sqlalchemy.text(
+            sa.text(
                 "ALTER TABLE index_record \
                 ADD COLUMN baseid VARCHAR DEFAULT NULL, \
                 ADD COLUMN created_date TIMESTAMP DEFAULT NOW(), \
@@ -1240,14 +1254,12 @@ def migrate_2(session, **kwargs):
         session.rollback()
     session.commit()
 
-    count = session.execute(
-        sqlalchemy.text("SELECT COUNT(*) FROM index_record")
-    ).fetchone()[0]
+    count = session.execute(sa.text("SELECT COUNT(*) FROM index_record")).fetchone()[0]
 
     # create tmp_index_record table for fast retrival
     try:
         session.execute(
-            sqlalchemy.text(
+            sa.text(
                 """
             CREATE TABLE tmp_index_record AS
                 SELECT did, ROW_NUMBER() OVER (ORDER BY did) AS RowNumber
@@ -1261,47 +1273,39 @@ def migrate_2(session, **kwargs):
     for loop in range(count):
         baseid = str(uuid.uuid4())
         session.execute(
-            sqlalchemy.text(
+            sa.text(
                 f"UPDATE index_record SET baseid = '{baseid}'\
              WHERE did =  (SELECT did FROM tmp_index_record WHERE RowNumber = {loop + 1})"
             )
         )
-        session.execute(
-            sqlalchemy.text(f"INSERT INTO base_version(baseid) VALUES('{baseid}')")
-        )
+        session.execute(sa.text(f"INSERT INTO base_version(baseid) VALUES('{baseid}')"))
 
     session.execute(
-        sqlalchemy.text(
+        sa.text(
             "ALTER TABLE index_record \
          ADD CONSTRAINT baseid_FK FOREIGN KEY (baseid) references base_version(baseid)"
         )
     )
 
     # drop tmp table
-    session.execute(sqlalchemy.text("DROP TABLE IF EXISTS tmp_index_record"))
+    session.execute(sa.text("DROP TABLE IF EXISTS tmp_index_record"))
 
 
 def migrate_3(session, **kwargs):
-    session.execute(
-        sqlalchemy.text("ALTER TABLE index_record ADD COLUMN file_name VARCHAR")
-    )
+    session.execute(sa.text("ALTER TABLE index_record ADD COLUMN file_name VARCHAR"))
 
     session.execute(
-        sqlalchemy.text(
+        sa.text(
             "CREATE INDEX index_record__file_name_idx ON index_record ( file_name )"
         )
     )
 
 
 def migrate_4(session, **kwargs):
-    session.execute(
-        sqlalchemy.text("ALTER TABLE index_record ADD COLUMN version VARCHAR")
-    )
+    session.execute(sa.text("ALTER TABLE index_record ADD COLUMN version VARCHAR"))
 
     session.execute(
-        sqlalchemy.text(
-            "CREATE INDEX index_record__version_idx ON index_record ( version )"
-        )
+        sa.text("CREATE INDEX index_record__version_idx ON index_record ( version )")
     )
 
 
@@ -1311,23 +1315,23 @@ def migrate_5(session, **kwargs):
     IndexRecordUrlMetadata tables
     """
     session.execute(
-        sqlalchemy.text("CREATE INDEX index_record_url_idx ON index_record_url ( did )")
+        sa.text("CREATE INDEX index_record_url_idx ON index_record_url ( did )")
     )
 
     session.execute(
-        sqlalchemy.text(
+        sa.text(
             f"CREATE INDEX {IndexRecordHash.__tablename__}_idx ON {IndexRecordHash.__tablename__} ( did )"
         )
     )
 
     session.execute(
-        sqlalchemy.text(
+        sa.text(
             f"CREATE INDEX {IndexRecordMetadata.__tablename__}_idx ON {IndexRecordMetadata.__tablename__} ( did )"
         )
     )
 
     session.execute(
-        sqlalchemy.text(
+        sa.text(
             f"CREATE INDEX {IndexRecordUrlMetadata.__tablename__}_idx ON {IndexRecordUrlMetadata.__tablename__} ( did )"
         )
     )
@@ -1354,9 +1358,7 @@ def migrate_8(session, **kwargs):
     create index on IndexRecord.baseid
     """
     session.execute(
-        sqlalchemy.text(
-            "CREATE INDEX ix_index_record_baseid ON index_record ( baseid )"
-        )
+        sa.text("CREATE INDEX ix_index_record_baseid ON index_record ( baseid )")
     )
 
 
@@ -1366,47 +1368,39 @@ def migrate_9(session, **kwargs):
     create index on IndexRecord.size
     """
     session.execute(
-        sqlalchemy.text("CREATE INDEX ix_index_record_size ON index_record ( size )")
+        sa.text("CREATE INDEX ix_index_record_size ON index_record ( size )")
     )
 
     session.execute(
-        sqlalchemy.text(
+        sa.text(
             f"CREATE INDEX index_record_hash_type_value_idx ON {IndexRecordHash.__tablename__} ( hash_value, hash_type )"
         )
     )
 
 
 def migrate_10(session, **kwargs):
-    session.execute(
-        sqlalchemy.text("ALTER TABLE index_record ADD COLUMN uploader VARCHAR")
-    )
+    session.execute(sa.text("ALTER TABLE index_record ADD COLUMN uploader VARCHAR"))
 
     session.execute(
-        sqlalchemy.text(
-            "CREATE INDEX index_record__uploader_idx ON index_record ( uploader )"
-        )
+        sa.text("CREATE INDEX index_record__uploader_idx ON index_record ( uploader )")
     )
 
 
 def migrate_11(session, **kwargs):
     session.execute(
-        sqlalchemy.text("ALTER TABLE index_record ADD COLUMN release_number VARCHAR")
+        sa.text("ALTER TABLE index_record ADD COLUMN release_number VARCHAR")
+    )
+    session.execute(sa.text("ALTER TABLE index_record ADD COLUMN index_metadata jsonb"))
+    session.execute(
+        sa.text("ALTER TABLE index_record DROP CONSTRAINT index_record_baseid_fkey")
     )
     session.execute(
-        sqlalchemy.text("ALTER TABLE index_record ADD COLUMN index_metadata jsonb")
-    )
-    session.execute(
-        sqlalchemy.text(
-            "ALTER TABLE index_record DROP CONSTRAINT index_record_baseid_fkey"
-        )
-    )
-    session.execute(
-        sqlalchemy.text(
+        sa.text(
             "ALTER TABLE index_record_metadata DROP CONSTRAINT index_record_metadata_did_fkey"
         )
     )
     session.execute(
-        sqlalchemy.text(
+        sa.text(
             "ALTER TABLE index_record_url DROP CONSTRAINT index_record_url_did_fkey"
         )
     )
@@ -1429,7 +1423,7 @@ def migrate_12(session, **kwargs):
 
         # metadata migration to jsonb
         session.execute(
-            sqlalchemy.text(
+            sa.text(
                 f"""
             UPDATE index_record r
             SET index_metadata = m.meta
@@ -1445,7 +1439,7 @@ def migrate_12(session, **kwargs):
         )
 
         session.execute(
-            sqlalchemy.text(
+            sa.text(
                 f"""
             UPDATE index_record r
             SET release_number = re.release_number
@@ -1461,7 +1455,7 @@ def migrate_12(session, **kwargs):
 
         # urls metadata migration to jsonb
         session.execute(
-            sqlalchemy.text(
+            sa.text(
                 f"""
             INSERT INTO index_record_url_metadata_jsonb (did, url)
             SELECT did, url
@@ -1472,7 +1466,7 @@ def migrate_12(session, **kwargs):
         )
 
         session.execute(
-            sqlalchemy.text(
+            sa.text(
                 f"""
             UPDATE index_record_url_metadata_jsonb as main
             SET urls_metadata = um.meta
@@ -1488,7 +1482,7 @@ def migrate_12(session, **kwargs):
         )
 
         session.execute(
-            sqlalchemy.text(
+            sa.text(
                 f"""
             UPDATE index_record_url_metadata_jsonb as main
             SET "type" = t.type
@@ -1503,7 +1497,7 @@ def migrate_12(session, **kwargs):
         )
 
         session.execute(
-            sqlalchemy.text(
+            sa.text(
                 f"""
             UPDATE index_record_url_metadata_jsonb as main
             SET state = s.state

--- a/src/indexd/index/drivers/alchemy.py
+++ b/src/indexd/index/drivers/alchemy.py
@@ -1,9 +1,9 @@
 import copy
-import datetime
 import logging
 import uuid
 from contextlib import contextmanager
 
+import sqlalchemy
 from sqlalchemy import (
     BigInteger,
     Column,
@@ -14,16 +14,14 @@ from sqlalchemy import (
     Integer,
     String,
     and_,
+    exc,
     func,
     not_,
     or_,
+    orm,
     select,
 )
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.exc import IntegrityError, ProgrammingError
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import joinedload, relationship, sessionmaker
-from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 
 from indexd.errors import UserError
 from indexd.index.driver import IndexDriverABC
@@ -36,7 +34,7 @@ from indexd.index.errors import (
 from indexd.utils import init_schema_version, is_empty_database, migrate_database
 
 logger = logging.getLogger(__name__)
-Base = declarative_base()
+Base = sqlalchemy.orm.declarative_base()
 
 
 class BaseVersion(Base):
@@ -77,32 +75,32 @@ class IndexRecord(Base):
     form = Column(String)
     size = Column(BigInteger, index=True)
     release_number = Column(String, index=True)
-    created_date = Column(DateTime, default=datetime.datetime.utcnow)
-    updated_date = Column(DateTime, default=datetime.datetime.utcnow)
+    created_date = Column(DateTime, server_default=sqlalchemy.text("now()"))
+    updated_date = Column(DateTime, server_default=sqlalchemy.text("now()"))
     file_name = Column(String, index=True)
     version = Column(String, index=True)
     uploader = Column(String, index=True)
     index_metadata = Column(JSONB)
 
-    urls_metadata = relationship(
+    urls_metadata = orm.relationship(
         "IndexRecordUrlMetadataJsonb",
         backref="index_record",
         cascade="all, delete-orphan",
     )
 
-    acl = relationship(
+    acl = orm.relationship(
         "IndexRecordACE",
         backref="index_record",
         cascade="all, delete-orphan",
     )
 
-    hashes = relationship(
+    hashes = orm.relationship(
         "IndexRecordHash",
         backref="index_record",
         cascade="all, delete-orphan",
     )
 
-    aliases = relationship(
+    aliases = orm.relationship(
         "IndexRecordAlias",
         backref="index_record",
         cascade="all, delete-orphan",
@@ -300,10 +298,10 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
         self.config = index_config or {}
 
         Base.metadata.bind = self.engine
-        self.Session = sessionmaker(bind=self.engine)
+        self._session_class = orm.sessionmaker(bind=self.engine)
 
         is_empty_db = is_empty_database(driver=self)
-        Base.metadata.create_all()
+        Base.metadata.create_all(bind=self.engine)
         if is_empty_db:
             init_schema_version(
                 driver=self,
@@ -331,7 +329,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
         """
         Provide a transactional scope around a series of operations.
         """
-        session = self.Session()
+        session = self._session_class()
 
         try:
             yield session
@@ -367,10 +365,10 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
 
             # Enable joinedload on all relationships so that we won't have to
             # do a bunch of selects when we assemble our response.
-            query = query.options(joinedload(IndexRecord.urls_metadata))
-            query = query.options(joinedload(IndexRecord.acl))
-            query = query.options(joinedload(IndexRecord.hashes))
-            query = query.options(joinedload(IndexRecord.aliases))
+            query = query.options(orm.joinedload(IndexRecord.urls_metadata))
+            query = query.options(orm.joinedload(IndexRecord.acl))
+            query = query.options(orm.joinedload(IndexRecord.hashes))
+            query = query.options(orm.joinedload(IndexRecord.aliases))
 
             if start is not None:
                 query = query.filter(IndexRecord.did > start)
@@ -723,7 +721,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
                 if self.config.get("ADD_PREFIX_ALIAS"):
                     self.add_prefix_alias(record, session)
                 session.commit()
-            except IntegrityError:
+            except exc.IntegrityError:
                 raise UserError(f'did "{record.did}" already exists', 400)
 
             return record.did, record.rev, record.baseid
@@ -769,9 +767,9 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
 
             try:
                 record = query.one()
-            except NoResultFound:
+            except exc.NoResultFound:
                 raise NoRecordFoundError("no record found")
-            except MultipleResultsFound:
+            except exc.MultipleResultsFound:
                 raise MultipleRecordsFoundError("multiple records found")
 
             if record.size or record.hashes:
@@ -819,9 +817,9 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
                     .filter(IndexRecord.aliases.any(name=alias))
                     .one()
                 )
-            except NoResultFound:
+            except exc.NoResultFound:
                 raise NoRecordFoundError("no record found")
-            except MultipleResultsFound:
+            except exc.MultipleResultsFound:
                 raise MultipleRecordsFoundError("multiple records found")
             return record.to_document_dict()
 
@@ -861,9 +859,9 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
 
             try:
                 record = query.one()
-            except NoResultFound:
+            except exc.NoResultFound:
                 raise NoRecordFoundError("no record found")
-            except MultipleResultsFound:
+            except exc.MultipleResultsFound:
                 raise MultipleRecordsFoundError("multiple records found")
 
             if rev != record.rev:
@@ -925,9 +923,9 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
 
             try:
                 record = query.one()
-            except NoResultFound:
+            except exc.NoResultFound:
                 raise NoRecordFoundError("no record found")
-            except MultipleResultsFound:
+            except exc.MultipleResultsFound:
                 raise MultipleRecordsFoundError("multiple records found")
 
             if rev != record.rev:
@@ -964,9 +962,9 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
 
             try:
                 record = query.one()
-            except NoResultFound:
+            except exc.NoResultFound:
                 raise NoRecordFoundError("no record found")
-            except MultipleResultsFound:
+            except exc.MultipleResultsFound:
                 raise MultipleRecordsFoundError("multiple records found")
 
             baseid = record.baseid
@@ -1010,7 +1008,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             try:
                 session.add(record)
                 session.commit()
-            except IntegrityError:
+            except exc.IntegrityError:
                 raise UserError(f"{did} already exists", 400)
 
             return record.did, record.baseid, record.rev
@@ -1032,13 +1030,13 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             try:
                 record = query.one()
                 baseid = record.baseid
-            except NoResultFound:
+            except exc.NoResultFound:
                 record = session.query(IndexRecord).filter_by(baseid=did).first()
                 if not record:
                     raise NoRecordFoundError("no record found")
                 else:
                     baseid = record.baseid
-            except MultipleResultsFound:
+            except exc.MultipleResultsFound:
                 raise MultipleRecordsFoundError("multiple records found")
 
             query = session.query(IndexRecord)
@@ -1075,9 +1073,9 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
             try:
                 record = query.one()
                 baseid = record.baseid
-            except NoResultFound:
+            except exc.NoResultFound:
                 baseid = did
-            except MultipleResultsFound:
+            except exc.MultipleResultsFound:
                 raise MultipleRecordsFoundError("multiple records found")
 
             query = session.query(IndexRecord)
@@ -1151,7 +1149,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
         """
         with self.session as session:
             try:
-                session.execute("SELECT 1")
+                session.execute(sqlalchemy.text("SELECT 1"))
             except Exception:
                 raise UnhealthyCheckError()
 
@@ -1220,7 +1218,9 @@ def extract_urls_metadata(urls_metadata_results):
 # change to a model is made, one or more migration steps might not work.
 # In the future consider using SQL queries to do the migrations.
 def migrate_1(session, **kwargs):
-    session.execute("ALTER TABLE index_record ALTER COLUMN size TYPE bigint")
+    session.execute(
+        sqlalchemy.text("ALTER TABLE index_record ALTER COLUMN size TYPE bigint")
+    )
 
 
 def migrate_2(session, **kwargs):
@@ -1229,59 +1229,79 @@ def migrate_2(session, **kwargs):
     """
     try:
         session.execute(
-            "ALTER TABLE index_record \
+            sqlalchemy.text(
+                "ALTER TABLE index_record \
                 ADD COLUMN baseid VARCHAR DEFAULT NULL, \
                 ADD COLUMN created_date TIMESTAMP DEFAULT NOW(), \
                 ADD COLUMN updated_date TIMESTAMP DEFAULT NOW()"
+            )
         )
-    except ProgrammingError:
+    except exc.ProgrammingError:
         session.rollback()
     session.commit()
 
-    count = session.execute("SELECT COUNT(*) FROM index_record").fetchone()[0]
+    count = session.execute(
+        sqlalchemy.text("SELECT COUNT(*) FROM index_record")
+    ).fetchone()[0]
 
     # create tmp_index_record table for fast retrival
     try:
         session.execute(
-            """
+            sqlalchemy.text(
+                """
             CREATE TABLE tmp_index_record AS
                 SELECT did, ROW_NUMBER() OVER (ORDER BY did) AS RowNumber
                 FROM index_record
         """
+            )
         )
-    except ProgrammingError:
+    except exc.ProgrammingError:
         session.rollback()
 
     for loop in range(count):
         baseid = str(uuid.uuid4())
         session.execute(
-            f"UPDATE index_record SET baseid = '{baseid}'\
+            sqlalchemy.text(
+                f"UPDATE index_record SET baseid = '{baseid}'\
              WHERE did =  (SELECT did FROM tmp_index_record WHERE RowNumber = {loop + 1})"
+            )
         )
-        session.execute(f"INSERT INTO base_version(baseid) VALUES('{baseid}')")
+        session.execute(
+            sqlalchemy.text(f"INSERT INTO base_version(baseid) VALUES('{baseid}')")
+        )
 
     session.execute(
-        "ALTER TABLE index_record \
+        sqlalchemy.text(
+            "ALTER TABLE index_record \
          ADD CONSTRAINT baseid_FK FOREIGN KEY (baseid) references base_version(baseid)"
+        )
     )
 
     # drop tmp table
-    session.execute("DROP TABLE IF EXISTS tmp_index_record")
+    session.execute(sqlalchemy.text("DROP TABLE IF EXISTS tmp_index_record"))
 
 
 def migrate_3(session, **kwargs):
-    session.execute("ALTER TABLE index_record ADD COLUMN file_name VARCHAR")
+    session.execute(
+        sqlalchemy.text("ALTER TABLE index_record ADD COLUMN file_name VARCHAR")
+    )
 
     session.execute(
-        "CREATE INDEX index_record__file_name_idx ON index_record ( file_name )"
+        sqlalchemy.text(
+            "CREATE INDEX index_record__file_name_idx ON index_record ( file_name )"
+        )
     )
 
 
 def migrate_4(session, **kwargs):
-    session.execute("ALTER TABLE index_record ADD COLUMN version VARCHAR")
+    session.execute(
+        sqlalchemy.text("ALTER TABLE index_record ADD COLUMN version VARCHAR")
+    )
 
     session.execute(
-        "CREATE INDEX index_record__version_idx ON index_record ( version )"
+        sqlalchemy.text(
+            "CREATE INDEX index_record__version_idx ON index_record ( version )"
+        )
     )
 
 
@@ -1290,18 +1310,26 @@ def migrate_5(session, **kwargs):
     Create Index did on IndexRecordUrl, IndexRecordMetadata and
     IndexRecordUrlMetadata tables
     """
-    session.execute("CREATE INDEX index_record_url_idx ON index_record_url ( did )")
-
     session.execute(
-        f"CREATE INDEX {IndexRecordHash.__tablename__}_idx ON {IndexRecordHash.__tablename__} ( did )"
+        sqlalchemy.text("CREATE INDEX index_record_url_idx ON index_record_url ( did )")
     )
 
     session.execute(
-        f"CREATE INDEX {IndexRecordMetadata.__tablename__}_idx ON {IndexRecordMetadata.__tablename__} ( did )"
+        sqlalchemy.text(
+            f"CREATE INDEX {IndexRecordHash.__tablename__}_idx ON {IndexRecordHash.__tablename__} ( did )"
+        )
     )
 
     session.execute(
-        f"CREATE INDEX {IndexRecordUrlMetadata.__tablename__}_idx ON {IndexRecordUrlMetadata.__tablename__} ( did )"
+        sqlalchemy.text(
+            f"CREATE INDEX {IndexRecordMetadata.__tablename__}_idx ON {IndexRecordMetadata.__tablename__} ( did )"
+        )
+    )
+
+    session.execute(
+        sqlalchemy.text(
+            f"CREATE INDEX {IndexRecordUrlMetadata.__tablename__}_idx ON {IndexRecordUrlMetadata.__tablename__} ( did )"
+        )
     )
 
 
@@ -1325,7 +1353,11 @@ def migrate_8(session, **kwargs):
     """
     create index on IndexRecord.baseid
     """
-    session.execute("CREATE INDEX ix_index_record_baseid ON index_record ( baseid )")
+    session.execute(
+        sqlalchemy.text(
+            "CREATE INDEX ix_index_record_baseid ON index_record ( baseid )"
+        )
+    )
 
 
 def migrate_9(session, **kwargs):
@@ -1333,30 +1365,50 @@ def migrate_9(session, **kwargs):
     create index on IndexRecordHash.hash_value
     create index on IndexRecord.size
     """
-    session.execute("CREATE INDEX ix_index_record_size ON index_record ( size )")
+    session.execute(
+        sqlalchemy.text("CREATE INDEX ix_index_record_size ON index_record ( size )")
+    )
 
     session.execute(
-        f"CREATE INDEX index_record_hash_type_value_idx ON {IndexRecordHash.__tablename__} ( hash_value, hash_type )"
+        sqlalchemy.text(
+            f"CREATE INDEX index_record_hash_type_value_idx ON {IndexRecordHash.__tablename__} ( hash_value, hash_type )"
+        )
     )
 
 
 def migrate_10(session, **kwargs):
-    session.execute("ALTER TABLE index_record ADD COLUMN uploader VARCHAR")
+    session.execute(
+        sqlalchemy.text("ALTER TABLE index_record ADD COLUMN uploader VARCHAR")
+    )
 
     session.execute(
-        "CREATE INDEX index_record__uploader_idx ON index_record ( uploader )"
+        sqlalchemy.text(
+            "CREATE INDEX index_record__uploader_idx ON index_record ( uploader )"
+        )
     )
 
 
 def migrate_11(session, **kwargs):
-    session.execute("ALTER TABLE index_record ADD COLUMN release_number VARCHAR")
-    session.execute("ALTER TABLE index_record ADD COLUMN index_metadata jsonb")
-    session.execute("ALTER TABLE index_record DROP CONSTRAINT index_record_baseid_fkey")
     session.execute(
-        "ALTER TABLE index_record_metadata DROP CONSTRAINT index_record_metadata_did_fkey"
+        sqlalchemy.text("ALTER TABLE index_record ADD COLUMN release_number VARCHAR")
     )
     session.execute(
-        "ALTER TABLE index_record_url DROP CONSTRAINT index_record_url_did_fkey"
+        sqlalchemy.text("ALTER TABLE index_record ADD COLUMN index_metadata jsonb")
+    )
+    session.execute(
+        sqlalchemy.text(
+            "ALTER TABLE index_record DROP CONSTRAINT index_record_baseid_fkey"
+        )
+    )
+    session.execute(
+        sqlalchemy.text(
+            "ALTER TABLE index_record_metadata DROP CONSTRAINT index_record_metadata_did_fkey"
+        )
+    )
+    session.execute(
+        sqlalchemy.text(
+            "ALTER TABLE index_record_url DROP CONSTRAINT index_record_url_did_fkey"
+        )
     )
 
 
@@ -1377,7 +1429,8 @@ def migrate_12(session, **kwargs):
 
         # metadata migration to jsonb
         session.execute(
-            f"""
+            sqlalchemy.text(
+                f"""
             UPDATE index_record r
             SET index_metadata = m.meta
             FROM (
@@ -1388,10 +1441,12 @@ def migrate_12(session, **kwargs):
             ) AS m
             WHERE r.did=m.did
         """
+            )
         )
 
         session.execute(
-            f"""
+            sqlalchemy.text(
+                f"""
             UPDATE index_record r
             SET release_number = re.release_number
             FROM (
@@ -1401,20 +1456,24 @@ def migrate_12(session, **kwargs):
             ) AS re
             WHERE r.did=re.did
         """
+            )
         )
 
         # urls metadata migration to jsonb
         session.execute(
-            f"""
+            sqlalchemy.text(
+                f"""
             INSERT INTO index_record_url_metadata_jsonb (did, url)
             SELECT did, url
             FROM index_record_url
             WHERE did>='{from_chunk}' AND did<'{to_chunk}'
         """
+            )
         )
 
         session.execute(
-            f"""
+            sqlalchemy.text(
+                f"""
             UPDATE index_record_url_metadata_jsonb as main
             SET urls_metadata = um.meta
             FROM (
@@ -1425,10 +1484,12 @@ def migrate_12(session, **kwargs):
             ) AS um
             WHERE main.did=um.did and main.url=um.url
         """
+            )
         )
 
         session.execute(
-            f"""
+            sqlalchemy.text(
+                f"""
             UPDATE index_record_url_metadata_jsonb as main
             SET "type" = t.type
             FROM (
@@ -1438,10 +1499,12 @@ def migrate_12(session, **kwargs):
             ) AS t
             WHERE main.did=t.did and main.url=t.url
         """
+            )
         )
 
         session.execute(
-            f"""
+            sqlalchemy.text(
+                f"""
             UPDATE index_record_url_metadata_jsonb as main
             SET state = s.state
             FROM (
@@ -1451,6 +1514,7 @@ def migrate_12(session, **kwargs):
             ) AS s
             WHERE main.did=s.did and main.url=s.url
         """
+            )
         )
 
 

--- a/src/indexd/index/drivers/alchemy.py
+++ b/src/indexd/index/drivers/alchemy.py
@@ -1206,7 +1206,7 @@ class SQLAlchemyIndexDriver(IndexDriverABC):
         """
         with self.session as session:
             return session.execute(
-                sa.select([func.count()]).select_from(IndexRecord)
+                sa.select(func.count("*")).select_from(IndexRecord)
             ).scalar()
 
 

--- a/src/indexd/utils.py
+++ b/src/indexd/utils.py
@@ -2,9 +2,10 @@ import logging
 import os
 import re
 
+import sqlalchemy
 import sqlalchemy_utils
 from sqlalchemy import create_engine
-from sqlalchemy.engine.reflection import Inspector
+from sqlalchemy.engine import Engine
 
 logger = logging.getLogger(__name__)
 
@@ -113,19 +114,23 @@ def setup_database(
 
     if not no_user:
         try:
-            user_stmt = f"CREATE USER {user} WITH PASSWORD '{password}'"
+            user_stmt = sqlalchemy.text(
+                f"CREATE USER {user} WITH PASSWORD '{password}'"
+            )
             conn.execute(user_stmt)
 
-            perm_stmt = f"GRANT ALL PRIVILEGES ON DATABASE {database} to {password}"
+            perm_stmt = sqlalchemy.text(
+                f"GRANT ALL PRIVILEGES ON DATABASE {database} to {password}"
+            )
             conn.execute(perm_stmt)
-            conn.execute("commit")
+            conn.commit()
         except Exception as e:
             logger.warning("Unable to add user: %s", e)
     conn.close()
     engine.dispose()
 
 
-def check_engine_for_migrate(engine):
+def check_engine_for_migrate(engine: Engine) -> bool:
     """
     check if a db engine support database migration
 
@@ -138,7 +143,7 @@ def check_engine_for_migrate(engine):
     return engine.dialect.supports_alter
 
 
-def init_schema_version(driver, model, current_version):
+def init_schema_version(driver, model, current_version: int) -> int:
     """
     initialize schema table with a initialized singleton of version
 
@@ -203,6 +208,6 @@ def is_empty_database(driver):
     Returns:
         Boolean
     """
-    table_list = Inspector.from_engine(driver.engine).get_table_names()
+    table_list = sqlalchemy.inspect(driver.engine).get_table_names()
 
     return len(table_list) == 0

--- a/src/indexd/utils.py
+++ b/src/indexd/utils.py
@@ -2,10 +2,9 @@ import logging
 import os
 import re
 
-import sqlalchemy
+import sqlalchemy as sa
 import sqlalchemy_utils
-from sqlalchemy import create_engine
-from sqlalchemy.engine import Engine
+from sqlalchemy import engine as sa_engine
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +33,7 @@ ROOT_PASS = os.getenv("PG_INDEXD_ROOT_PASS")
 
 def __root_user_auth(user: str, password: str | None = None) -> str | None:
     if not user:
-        return
+        return None
     return user if not password else f"{user}:{password}"
 
 
@@ -67,12 +66,12 @@ def try_drop_test_data(
     if not drop_db:
         return
 
-    engine = create_engine(f"postgresql://{root_auth}@{host}/{database}")
+    _engine = sa.create_engine(f"postgresql://{root_auth}@{host}/{database}")
 
-    if sqlalchemy_utils.database_exists(engine.url):
-        sqlalchemy_utils.drop_database(engine.url)
+    if sqlalchemy_utils.database_exists(_engine.url):
+        sqlalchemy_utils.drop_database(_engine.url)
 
-    engine.dispose()
+    _engine.dispose()
 
 
 def setup_database(
@@ -106,7 +105,7 @@ def setup_database(
 
     # Create an engine connecting to the `postgres` database allows us to
     # create a new database from there.
-    engine = create_engine(f"postgresql://{auth}@{host}/{database}")
+    engine = sa.create_engine(f"postgresql://{auth}@{host}/{database}")
     if not sqlalchemy_utils.database_exists(engine.url):
         sqlalchemy_utils.create_database(engine.url)
 
@@ -114,12 +113,10 @@ def setup_database(
 
     if not no_user:
         try:
-            user_stmt = sqlalchemy.text(
-                f"CREATE USER {user} WITH PASSWORD '{password}'"
-            )
+            user_stmt = sa.text(f"CREATE USER {user} WITH PASSWORD '{password}'")
             conn.execute(user_stmt)
 
-            perm_stmt = sqlalchemy.text(
+            perm_stmt = sa.text(
                 f"GRANT ALL PRIVILEGES ON DATABASE {database} to {password}"
             )
             conn.execute(perm_stmt)
@@ -130,7 +127,7 @@ def setup_database(
     engine.dispose()
 
 
-def check_engine_for_migrate(engine: Engine) -> bool:
+def check_engine_for_migrate(engine: sa_engine.Engine) -> bool:
     """
     check if a db engine support database migration
 
@@ -208,6 +205,6 @@ def is_empty_database(driver):
     Returns:
         Boolean
     """
-    table_list = sqlalchemy.inspect(driver.engine).get_table_names()
+    table_list = sa.inspect(driver.engine).get_table_names()
 
     return len(table_list) == 0

--- a/tests/integration/alchemy.py
+++ b/tests/integration/alchemy.py
@@ -1,10 +1,10 @@
+import sqlalchemy
 from sqlalchemy import BigInteger, Column, ForeignKey, String
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, sessionmaker
 
 from indexd.driver_base import SQLAlchemyDriverBase
 
-Base = declarative_base()
+Base = sqlalchemy.orm.declarative_base()
 CURRENT_SCHEMA_VERSION = 2
 
 
@@ -66,6 +66,6 @@ class SQLAlchemyIndexTestDriver(SQLAlchemyDriverBase):
         super().__init__(conn, **config)
 
         Base.metadata.bind = self.engine
-        Base.metadata.create_all()
+        Base.metadata.create_all(bind=self.engine)
 
         self.Session = sessionmaker(bind=self.engine)

--- a/tests/integration/alchemy.py
+++ b/tests/integration/alchemy.py
@@ -1,10 +1,9 @@
-import sqlalchemy
-from sqlalchemy import BigInteger, Column, ForeignKey, String
-from sqlalchemy.orm import relationship, sessionmaker
+import sqlalchemy as sa
+from sqlalchemy import orm
 
 from indexd.driver_base import SQLAlchemyDriverBase
 
-Base = sqlalchemy.orm.declarative_base()
+Base = orm.declarative_base()
 CURRENT_SCHEMA_VERSION = 2
 
 
@@ -15,21 +14,21 @@ class IndexRecord(Base):
 
     __tablename__ = "index_record"
 
-    did = Column(String, primary_key=True)
+    did = sa.Column(sa.String, primary_key=True)
 
-    rev = Column(String)
-    form = Column(String)
-    size = Column(BigInteger)
+    rev = sa.Column(sa.String)
+    form = sa.Column(sa.String)
+    size = sa.Column(sa.BigInteger)
 
-    urls = relationship(
+    urls = orm.relationship(
         "IndexRecordUrl",
-        backref="index_record",
+        back_populates="index_record",
         cascade="all, delete-orphan",
     )
 
-    hashes = relationship(
+    hashes = orm.relationship(
         "IndexRecordHash",
-        backref="index_record",
+        back_populates="index_record",
         cascade="all, delete-orphan",
     )
 
@@ -41,8 +40,8 @@ class IndexRecordUrl(Base):
 
     __tablename__ = "index_record_url"
 
-    did = Column(String, ForeignKey("index_record.did"), primary_key=True)
-    url = Column(String, primary_key=True)
+    did = sa.Column(sa.String, sa.ForeignKey("index_record.did"), primary_key=True)
+    url = sa.Column(sa.String, primary_key=True)
 
 
 class IndexRecordHash(Base):
@@ -52,9 +51,9 @@ class IndexRecordHash(Base):
 
     __tablename__ = "index_record_hash"
 
-    did = Column(String, ForeignKey("index_record.did"), primary_key=True)
-    hash_type = Column(String, primary_key=True)
-    hash_value = Column(String)
+    did = sa.Column(sa.String, sa.ForeignKey("index_record.did"), primary_key=True)
+    hash_type = sa.Column(sa.String, primary_key=True)
+    hash_value = sa.Column(sa.String)
 
 
 class SQLAlchemyIndexTestDriver(SQLAlchemyDriverBase):
@@ -68,4 +67,4 @@ class SQLAlchemyIndexTestDriver(SQLAlchemyDriverBase):
         Base.metadata.bind = self.engine
         Base.metadata.create_all(bind=self.engine)
 
-        self.Session = sessionmaker(bind=self.engine)
+        self.Session = orm.sessionmaker(bind=self.engine)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,12 +1,13 @@
 import base64
+import multiprocessing
 import os
-import threading
 
 import flask
 import pytest
 import requests
+import sqlalchemy
 import swagger_client
-from sqlalchemy import create_engine
+from _pytest import fixtures
 
 from indexd import utils as indexd_utils
 from indexd.alias.drivers.alchemy import Base as AliasBase
@@ -55,7 +56,7 @@ def truncate_tables(driver, base):
         for table in reversed(base.metadata.sorted_tables):
             # do not clear schema versions so each test does not re-trigger migration.
             if table.name not in ["index_schema_version", "alias_schema_version"]:
-                txn.execute(f"TRUNCATE {table.name} CASCADE;")
+                txn.execute(sqlalchemy.text(f"TRUNCATE {table.name} CASCADE;"))
 
 
 @pytest.fixture
@@ -135,7 +136,7 @@ def create_indexd_tables_no_migrate(
 
 
 @pytest.fixture(scope="session")
-def indexd_server():
+def indexd_server(request: fixtures.SubRequest) -> "MockServer":
     """
     Starts the indexd server, and cleans up its mess.
     Most tests will use the client which stems from this
@@ -143,8 +144,8 @@ def indexd_server():
 
     Runs once per test session.
     """
-    app = get_app()
-    app.config["DIST"].append(
+    _app = get_app()
+    _app.config["DIST"].append(
         {
             "name": "test",
             "host": f"http://localhost:{INDEXD_TEST_PORT}/index/",
@@ -155,14 +156,19 @@ def indexd_server():
     hostname = "localhost"
     port = INDEXD_TEST_PORT
     debug = False
-    t = threading.Thread(
-        target=app.run,
-        daemon=True,
+    t = multiprocessing.Process(
+        target=_app.run,
         kwargs={"host": hostname, "port": port, "debug": debug},
     )
     t.start()
+
+    def stop_thread():
+        t.join(timeout=1)
+        t.terminate()
+
     wait_for_indexd_alive(port)
-    yield MockServer(port=port)
+    request.addfinalizer(stop_thread)
+    return MockServer(port=port)
 
 
 def wait_for_indexd_alive(port):
@@ -286,7 +292,7 @@ def swg_bulk_client_no_migrate(swg_config_no_migrate):
 
 @pytest.fixture
 def database_engine():
-    engine = create_engine(PG_URL)
+    engine = sqlalchemy.create_engine(PG_URL)
     yield engine
     engine.dispose()
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,7 +2,6 @@ import base64
 import multiprocessing
 import os
 
-import flask
 import pytest
 import requests
 import sqlalchemy
@@ -12,7 +11,7 @@ from _pytest import fixtures
 from indexd import utils as indexd_utils
 from indexd.alias.drivers.alchemy import Base as AliasBase
 from indexd.alias.drivers.alchemy import SQLAlchemyAliasDriver
-from indexd.app import app_init, get_app
+from indexd.app import get_app
 from indexd.auth.drivers.alchemy import SQLAlchemyAuthDriver
 from indexd.index.drivers.alchemy import Base as IndexBase
 from indexd.index.drivers.alchemy import SQLAlchemyIndexDriver
@@ -194,7 +193,6 @@ def app(index_driver, alias_driver, auth_driver):
     it goes through an entire migration process that creates all the tables.
     The tables are already created from the fixtures in this module.
     """
-    app = flask.Flask("indexd")
     settings = {
         "config": {
             "INDEX": {
@@ -206,8 +204,7 @@ def app(index_driver, alias_driver, auth_driver):
         },
         "auth": auth_driver,
     }
-    app_init(app, settings=settings)
-    return app
+    return get_app(_settings=settings)
 
 
 @pytest.fixture

--- a/tests/integration/test_schema_migration.py
+++ b/tests/integration/test_schema_migration.py
@@ -1,7 +1,7 @@
 import uuid
 
-from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
+import pytest
+import sqlalchemy
 from sqlalchemy_utils import database_exists, drop_database
 
 from indexd import utils as indexd_utils
@@ -19,7 +19,7 @@ from indexd.index.drivers.alchemy import (
 from tests.integration.alchemy import SQLAlchemyIndexTestDriver
 from tests.integration.util import make_sql_statement
 
-Base = declarative_base()
+Base = sqlalchemy.orm.declarative_base()
 
 TEST_DB = f"postgresql://{indexd_utils.IndexdConfig['root_auth']}@{indexd_utils.IndexdConfig['host']}/test_migration_db"
 
@@ -113,25 +113,25 @@ def test_migrate_7(
             (did, hash_type, hash_value),
         )
     )
-
+    database_conn.commit()
     with index_driver_no_migrate.session as session:
         migrate_7(session)
 
     rows = database_conn.execute(
-        """
+        sqlalchemy.text("""
         SELECT ace
         FROM index_record_ace
-    """
+    """)
     )
 
     acls = ace_value.split(",")
     for row in rows:
-        assert row["ace"] in acls
+        assert row.ace in acls
     rows = database_conn.execute(
-        """
+        sqlalchemy.text("""
         SELECT *
         FROM index_record_metadata
-    """
+    """)
     )
 
     assert rows.rowcount == 0
@@ -252,11 +252,12 @@ def test_migrate_12(
         )
     )
 
+    database_conn.commit()
     rows = database_conn.execute(
-        """
+        sqlalchemy.text("""
         SELECT *
         FROM index_record_url_metadata
-    """
+    """)
     )
 
     # Each key:value pair is on a separate row at this point.
@@ -267,11 +268,11 @@ def test_migrate_12(
 
     # Check index table to see if the data transferred from the metadata table.
     rows = database_conn.execute(
-        f"""
+        sqlalchemy.text(f"""
         SELECT release_number, index_metadata
         FROM index_record
         WHERE did = '{dida}'
-    """
+    """)
     )
     assert rows.rowcount == 1
 
@@ -283,11 +284,11 @@ def test_migrate_12(
         }
 
     rows = database_conn.execute(
-        f"""
+        sqlalchemy.text(f"""
         SELECT release_number, index_metadata
         FROM index_record
         WHERE did = '{didb}'
-    """
+    """)
     )
     assert rows.rowcount == 1
 
@@ -299,11 +300,11 @@ def test_migrate_12(
 
     # Check url_metadata table to see if the data transferred to the jsonb table.
     rows = database_conn.execute(
-        f"""
+        sqlalchemy.text(f"""
         SELECT *
         FROM index_record_url_metadata_jsonb
         WHERE did='{dida}'
-    """
+    """)
     )
     assert rows.rowcount == 1
 
@@ -318,11 +319,11 @@ def test_migrate_12(
         }
 
     rows = database_conn.execute(
-        f"""
+        sqlalchemy.text(f"""
         SELECT *
         FROM index_record_url_metadata_jsonb
         WHERE did='{didb}'
-    """
+    """)
     )
     assert rows.rowcount == 1
 
@@ -334,6 +335,7 @@ def test_migrate_12(
         assert row.urls_metadata is None
 
 
+@pytest.mark.skip(reason="Test does not execute inner function")
 def test_migrate_index(index_driver_no_migrate, database_conn):
     def test_migrate_index_internal(monkeypatch):
         called = []
@@ -360,6 +362,7 @@ def test_migrate_index(index_driver_no_migrate, database_conn):
     return test_migrate_index_internal
 
 
+@pytest.mark.skip(reason="Test does not execute inner function")
 def test_migrate_index_only_diff(index_driver_no_migrate, database_conn):
     def test_migrate_index_only_diff_internal(monkeypatch):
         called = []
@@ -399,6 +402,7 @@ def test_migrate_index_only_diff(index_driver_no_migrate, database_conn):
     return test_migrate_index_only_diff_internal
 
 
+@pytest.mark.skip(reason="Test does not execute inner function")
 def test_migrate_alias(alias_driver, database_conn):
     def test_migrate_alias_internal(monkeypatch):
         called = []
@@ -424,7 +428,7 @@ def test_migrate_alias(alias_driver, database_conn):
 
 
 def test_migrate_index_versioning(monkeypatch, index_driver_no_migrate, database_conn):
-    engine = create_engine(TEST_DB)
+    engine = sqlalchemy.create_engine(TEST_DB)
     if database_exists(engine.url):
         drop_database(engine.url)
 
@@ -444,12 +448,12 @@ def test_migrate_index_versioning(monkeypatch, index_driver_no_migrate, database
         size = 512
         form = "object"
         conn.execute(
-            f"""
+            sqlalchemy.text(f"""
             INSERT INTO index_record(did, rev, form, size)
             VALUES ('{did}','{rev}','{form}',{size})
-        """
+        """)
         )
-    conn.execute("commit")
+    conn.commit()
     conn.close()
     engine.dispose()
 
@@ -469,21 +473,25 @@ def test_migrate_index_versioning(monkeypatch, index_driver_no_migrate, database
     conn = driver.engine.connect()
     for table, schema in INDEX_TABLES.items():
         cols = conn.execute(
-            f"\
+            sqlalchemy.text(
+                f"\
             SELECT column_name, data_type \
             FROM information_schema.columns \
             WHERE table_schema = 'public' AND table_name = '{table}'"
+            )
         )
         assert schema == [i for i in cols]
 
-    vids = conn.execute("SELECT baseid FROM index_record").fetchall()
+    vids = conn.execute(sqlalchemy.text("SELECT baseid FROM index_record")).fetchall()
 
     for baseid in vids:
         c = conn.execute(
-            f"\
+            sqlalchemy.text(
+                f"\
             SELECT COUNT(*) AS number_rows \
             FROM index_record \
             WHERE baseid = '{baseid[0]}'"
+            )
         ).fetchone()[0]
         assert c == 1
     conn.close()

--- a/tests/integration/test_schema_migration.py
+++ b/tests/integration/test_schema_migration.py
@@ -2,6 +2,7 @@ import uuid
 
 import pytest
 import sqlalchemy
+from sqlalchemy import orm
 from sqlalchemy_utils import database_exists, drop_database
 
 from indexd import utils as indexd_utils
@@ -19,7 +20,7 @@ from indexd.index.drivers.alchemy import (
 from tests.integration.alchemy import SQLAlchemyIndexTestDriver
 from tests.integration.util import make_sql_statement
 
-Base = sqlalchemy.orm.declarative_base()
+Base = orm.declarative_base()
 
 TEST_DB = f"postgresql://{indexd_utils.IndexdConfig['root_auth']}@{indexd_utils.IndexdConfig['host']}/test_migration_db"
 

--- a/tests/integration/test_setup.py
+++ b/tests/integration/test_setup.py
@@ -1,4 +1,6 @@
 # column name, data type, nullable, default value, primary key
+import sqlalchemy
+
 INDEX_TABLES = {
     "index_record": [
         ("did", "character varying", "NO", None, "PRIMARY KEY"),
@@ -7,8 +9,8 @@ INDEX_TABLES = {
         ("form", "character varying", "YES", None, None),
         ("size", "bigint", "YES", None, None),
         ("release_number", "character varying", "YES", None, None),
-        ("created_date", "timestamp without time zone", "YES", None, None),
-        ("updated_date", "timestamp without time zone", "YES", None, None),
+        ("created_date", "timestamp without time zone", "YES", "now()", None),
+        ("updated_date", "timestamp without time zone", "YES", "now()", None),
         ("file_name", "character varying", "YES", None, None),
         ("version", "character varying", "YES", None, None),
         ("uploader", "character varying", "YES", None, None),
@@ -73,12 +75,12 @@ def test_postgres_index_setup_tables(index_driver, database_conn):
 
     # postgres
     c = database_conn.execute(
-        """
+        sqlalchemy.text("""
         SELECT table_name
         FROM information_schema.tables
         WHERE table_schema='public'
         AND table_type='BASE TABLE'
-    """
+    """)
     )
 
     tables = [i[0] for i in c]
@@ -89,7 +91,7 @@ def test_postgres_index_setup_tables(index_driver, database_conn):
     for table, schema in INDEX_TABLES.items():
         # Index, column name, data type, nullable, default value, primary key
         c = database_conn.execute(
-            f"""
+            sqlalchemy.text(f"""
             SELECT col.column_name, col.data_type, col.is_nullable,
                 col.column_default, c.constraint_type
             FROM information_schema.columns col
@@ -102,7 +104,7 @@ def test_postgres_index_setup_tables(index_driver, database_conn):
                 ) c
             ON col.column_name =  c.column_name
             WHERE table_name = '{table}'
-        """
+        """)
         )
 
         assert schema == [i for i in c]
@@ -114,12 +116,12 @@ def test_postgres_alias_setup_tables(alias_driver, database_conn):
     """
 
     c = database_conn.execute(
-        """
+        sqlalchemy.text("""
         SELECT table_name
         FROM information_schema.tables
         WHERE table_schema='public'
         AND table_type='BASE TABLE'
-    """
+    """)
     )
 
     tables = [i[0] for i in c]
@@ -130,7 +132,7 @@ def test_postgres_alias_setup_tables(alias_driver, database_conn):
     for table, schema in ALIAS_TABLES.items():
         # Index, column name, data type, nullable, default value, primary key
         c = database_conn.execute(
-            f"""
+            sqlalchemy.text(f"""
             SELECT col.column_name, col.data_type, col.is_nullable,
                 col.column_default, c.constraint_type
             FROM information_schema.columns col
@@ -143,7 +145,7 @@ def test_postgres_alias_setup_tables(alias_driver, database_conn):
                 ) c
             ON col.column_name =  c.column_name
             WHERE table_name = '{table}'
-        """
+        """)
         )
 
         assert schema == [i for i in c]

--- a/tests/integration/test_urls_endpoints.py
+++ b/tests/integration/test_urls_endpoints.py
@@ -169,3 +169,8 @@ def test_status(client):
     resp = client.get("/_status")
     assert resp.status_code == 200
     assert resp.data == b"Healthy"
+
+
+def test_stats_endpoint(client):
+    resp = client.get("/_stats")
+    assert resp.status_code == 200

--- a/tests/integration/util.py
+++ b/tests/integration/util.py
@@ -1,5 +1,7 @@
 import datetime
 
+import sqlalchemy
+
 
 def assert_blank(r):
     """
@@ -43,4 +45,4 @@ def make_sql_statement(statement, args):
 
         statement = statement.replace("?", arg, 1)
 
-    return statement.strip()
+    return sqlalchemy.text(statement.strip())

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,8 @@ isolated_build = true
 passenv =
     PG_*
     PIP_INDEX_URL
+    LOGSTICK_*
+    SQLALCHEMY_*
 setenv =
     DD_BOTOCORE_DISTRIBUTED_TRACING=False
     DD_INSTRUMENTATION_TELEMETRY_ENABLED=False
@@ -41,7 +43,6 @@ commands =
     python -m pytest --junitxml=report.xml --cov=indexd --cov-report html --cov-report term --cov-report xml:coverage.xml {posargs}
 
 commands_post =
-    rm -r swagger_client
 
 [testenv:lint]
 basepython = python3.12


### PR DESCRIPTION
- Upgrade sqlalchemy from 1.3+ to 2+, fixed a bunch deprecations both in test and in main code
- Reduced warnings in test from 688 to 6. The 6 is from external libraries
- Skipped 3 tests that do not execute as expected due to how the test were written (actual test was in an inner function)
- switch ddtrace.patch_all to ddtrace.auto as patch_all is deprecated and will be removed in future