### PR TITLE
DEV-3655: bump minimum ddtrace version; update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,25 +12,25 @@ attrs==25.3.0
     #   referencing
 blinker==1.9.0
     # via flask
-bytecode==0.16.2
+bytecode==0.17.0
     # via ddtrace
-certifi==2025.7.14
+certifi==2025.8.3
     # via requests
-charset-normalizer==3.4.2
+charset-normalizer==3.4.3
     # via requests
-click==8.2.1
+click==8.3.0
     # via flask
 colorama==0.4.6
     # via logstick
 colorlog==6.9.0
     # via logstick
-ddtrace==3.14.3
+ddtrace==3.15.0
     # via indexd (pyproject.toml)
 deprecated==1.2.18
     # via logstick
 envier==0.6.1
     # via ddtrace
-flask==3.1.1
+flask==3.1.2
     # via indexd (pyproject.toml)
 gunicorn==23.0.0
     # via indexd (pyproject.toml)
@@ -44,28 +44,28 @@ jinja2==3.1.6
     # via flask
 json-log-formatter==1.1.1
     # via indexd (pyproject.toml)
-jsonschema==4.25.0
+jsonschema==4.25.1
     # via indexd (pyproject.toml)
-jsonschema-specifications==2025.4.1
+jsonschema-specifications==2025.9.1
     # via jsonschema
 legacy-cgi==2.6.3
     # via ddtrace
 logstick==0.1.6
     # via indexd (pyproject.toml)
-markdown-it-py==3.0.0
+markdown-it-py==4.0.0
     # via rich
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via
     #   flask
     #   jinja2
     #   werkzeug
 mdurl==0.1.2
     # via markdown-it-py
-opentelemetry-api==1.36.0
+opentelemetry-api==1.37.0
     # via ddtrace
 packaging==25.0
     # via gunicorn
-protobuf==6.31.1
+protobuf==6.32.1
     # via ddtrace
 psycopg2==2.9.10
     # via indexd (pyproject.toml)
@@ -75,27 +75,26 @@ referencing==0.36.2
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.4
+requests==2.32.5
     # via indexd (pyproject.toml)
 rich==14.1.0
     # via logstick
-rpds-py==0.26.0
+rpds-py==0.27.1
     # via
     #   jsonschema
     #   referencing
-setproctitle==1.3.6
+setproctitle==1.3.7
     # via indexd (pyproject.toml)
-sqlalchemy==2.0.42
+sqlalchemy==2.0.43
     # via
     #   indexd (pyproject.toml)
     #   sqlalchemy-utils
-sqlalchemy-utils==0.41.2
+sqlalchemy-utils==0.42.0
     # via indexd (pyproject.toml)
 structlog==25.4.0
     # via logstick
-typing-extensions==4.14.1
+typing-extensions==4.15.0
     # via
-    #   ddtrace
     #   indexd (pyproject.toml)
     #   opentelemetry-api
     #   sqlalchemy
@@ -105,7 +104,7 @@ werkzeug==3.1.3
     # via
     #   flask
     #   indexd (pyproject.toml)
-wrapt==1.17.2
+wrapt==1.17.3
     # via
     #   ddtrace
     #   deprecated

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     sqlalchemy-utils>=0.32
     psycopg2>=2.7
     requests>=2.32.4
-    ddtrace>=2.9.1
+    ddtrace>=3.15.0
     typing-extensions
     zipp>=3.19.1
     werkzeug>=3.0.6


### PR DESCRIPTION
There are no effective package version updates here. We're just locking in what we have and bumping `ddtrace` so Snyk stops complaining about a package `ddtrace` used to use but doesn't any longer.