### PR TITLE
DEV-3922: remove versionista

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61", "wheel", "setuptools_scm>=7"]
+requires = ["setuptools>=61", "setuptools-scm>=7"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61", "wheel", "setuptools_scm>=7", "versionista>=1.1.0"]
+requires = ["setuptools>=61", "wheel", "setuptools_scm>=7"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -90,8 +90,7 @@ known-first-party = ["indexd"]
 keep-runtime-typing = true
 
 [tool.setuptools_scm]
-local_scheme = "versionista-local-format"
-version_scheme = "versionista-format"
+fallback_version = "0.0.0"
 
 [[tool.uv.index]]
 name = "nexus"


### PR DESCRIPTION
We are discontinuing our use of versionista. Which is good, because it's not working now. This might be because of uv-related changes, I'm not sure. Anyway, this PR gets rid of versionista.